### PR TITLE
[Incremental] JENKINS-55523: Add verification of zone to KubernetesEnginePublisher.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -44,7 +44,8 @@ public class ComputeClient {
    * Retrieves a list of {@link Zone} objects from the container client.
    *
    * @param projectId The ID of the project that zone usage is needed for.
-   * @return The retrieved list of {@link Zone} objects.
+   * @return The retrieved list of {@link Zone} objects. This will not be null if the request was
+   *     successful.
    * @throws IOException When an error occurred attempting to get the list of zones.
    */
   public List<Zone> getZones(String projectId) throws IOException {

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
@@ -8,3 +8,6 @@ KubernetesEnginePublisher.CredentialProjectIDRequired=Project ID required to val
 KubernetesEnginePublisher.CredentialAuthFailed=Credentials failed to authenticate
 KubernetesEnginePublisher.ZoneRequired=Zone is required
 KubernetesEnginePublisher.ZoneFillError=Error retrieving zones
+KubernetesEnginePublisher.ZoneProjectIdCredentialRequired=Project ID and credential required to verify zone
+KubernetesEnginePublisher.ZoneNotInProject=Zone is not associated with the project ID
+KubernetesEnginePublisher.ZoneVerificationError=Error retrieving zones for verification

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -140,6 +140,15 @@ public class KubernetesEnginePublisherTest {
     assertEquals(Messages.KubernetesEnginePublisher_ZoneVerificationError(), result.getMessage());
   }
 
+  @Test
+  public void testDoCheckZoneOKWithMatchingZones() {
+    listOfZones.add(new Zone().setName(TEST_ZONE_A));
+    FormValidation result =
+        descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+    assertNotNull(result);
+    assertEquals(FormValidation.ok(), result);
+  }
+
   private void testZoneEmptyResult(ListBoxModel zones) {
     assertNotNull(zones);
     assertEquals(1, zones.size());

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -63,13 +63,16 @@ public class KubernetesEnginePublisherTest {
   }
 
   @Test
-  public void testDoFillZoneItemsEmptyWithEmptyArguments() {
+  public void testDoFillZoneItemsEmptyWithEmptyProjectId() {
     listOfZones.add(new Zone().setName(TEST_ZONE_A));
     ListBoxModel zones = descriptor.doFillZoneItems(jenkins, null, TEST_CREDENTIALS_ID);
     testZoneEmptyResult(zones);
-    zones = descriptor.doFillZoneItems(jenkins, TEST_PROJECT_ID, null);
-    testZoneEmptyResult(zones);
-    zones = descriptor.doFillZoneItems(jenkins, null, null);
+  }
+
+  @Test
+  public void testDoFillZoneItemsEmptyWithEmptyCredentialsId() {
+    listOfZones.add(new Zone().setName(TEST_ZONE_A));
+    ListBoxModel zones = descriptor.doFillZoneItems(jenkins, TEST_PROJECT_ID, null);
     testZoneEmptyResult(zones);
   }
 
@@ -108,26 +111,34 @@ public class KubernetesEnginePublisherTest {
   }
 
   @Test
-  public void testDoCheckZoneMessageWithEmptyProjectOrCredentialsId() {
+  public void testDoCheckZoneMessageWithEmptyProjectId() {
     FormValidation result = descriptor.doCheckZone(jenkins, TEST_ZONE_A, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEnginePublisher_ZoneProjectIdCredentialRequired(), result.getMessage());
-    result = descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, null);
     assertNotNull(result);
     assertEquals(
         Messages.KubernetesEnginePublisher_ZoneProjectIdCredentialRequired(), result.getMessage());
   }
 
   @Test
-  public void testDoCheckZoneMessageWithNoMatchingZones() {
+  public void testDoCheckZoneMessageWithEmptyCredentialsId() {
+    FormValidation result = descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, null);
+    assertNotNull(result);
+    assertEquals(
+        Messages.KubernetesEnginePublisher_ZoneProjectIdCredentialRequired(), result.getMessage());
+  }
+
+  @Test
+  public void testDoCheckZoneMessageWithNoAvailableZones() {
     FormValidation result =
         descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertNotNull(result);
     assertEquals(Messages.KubernetesEnginePublisher_ZoneNotInProject(), result.getMessage());
+  }
 
+  @Test
+  public void testDoCheckZoneMessageWithNonMatchingZones() {
     listOfZones.add(new Zone().setName(TEST_ZONE_B));
-    result = descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+    FormValidation result =
+        descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertNotNull(result);
     assertEquals(Messages.KubernetesEnginePublisher_ZoneNotInProject(), result.getMessage());
   }


### PR DESCRIPTION
This adds verification for entering zone and messages to the user whether 1) the zone can be verified or 2) if so, is the zone a valid zone for the given project ID.