### PR TITLE
[Incremental] JENKINS-55523: Auto-populate Project ID in new dropdown when possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
   <version>v1-rev199-1.22.0</version>
       </dependency>
       <dependency>
+        <groupId>com.google.apis</groupId>
+        <artifactId>google-api-services-cloudresourcemanager</artifactId>
+        <version>v1-rev535-1.25.0</version>
+      </dependency>
+      <dependency>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client</artifactId>
   <version>1.25.0</version>

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -337,7 +337,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
         @AncestorInPath Jenkins context,
         @QueryParameter("credentialsId") final String credentialsId) {
       ListBoxModel items = new ListBoxModel();
-      items.add("- none -");
+      items.add("- none -", "");
       if (Strings.isNullOrEmpty(credentialsId)) {
         return items;
       }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -373,6 +373,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
         }
         return items;
       } catch (IOException ioe) {
+        LOGGER.severe(ioe.getMessage());
         items.add(new Option(defaultProjectId, defaultProjectId, true));
         return items;
       }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -373,13 +373,14 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
         }
         return items;
       } catch (IOException ioe) {
-        LOGGER.severe(ioe.getMessage());
+        LOGGER.log(Level.SEVERE, Messages.KubernetesEnginePublisher_ProjectIDFillError(), ioe);
         items.add(new Option(defaultProjectId, defaultProjectId, true));
         return items;
       }
     }
 
-    // TODO(stephenshank): Validate projectId against list of projects from CloudResourceManagerClient
+    // TODO(stephenshank): Validate projectId against list of projects from
+    // CloudResourceManagerClient
     public FormValidation doCheckProjectId(@QueryParameter("projectId") String projectId) {
       if (Strings.isNullOrEmpty(projectId)) {
         return FormValidation.error(Messages.KubernetesEnginePublisher_ProjectIDRequired());

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -356,18 +356,20 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
         CloudResourceManagerClient client = clientFactory.cloudResourceManagerClient();
         List<Project> projects = client.getAccountProjects();
 
-        if (!projects.isEmpty()) {
-          projects
-              .stream()
-              .filter(p -> !p.getProjectId().equals(defaultProjectId))
-              .forEach(p -> items.add(p.getProjectId()));
-          if (projects.size() > items.size() - 1 && !Strings.isNullOrEmpty(defaultProjectId)) {
-            items.add(new Option(defaultProjectId, defaultProjectId, true));
-          } else {
-            // Select not the first (empty) item but the second item, which exists because
-            // projects is not empty.
-            items.get(1).selected = true;
-          }
+        if (projects.isEmpty()) {
+          return items;
+        }
+
+        projects
+            .stream()
+            .filter(p -> !p.getProjectId().equals(defaultProjectId))
+            .forEach(p -> items.add(p.getProjectId()));
+        if (projects.size() > items.size() - 1 && !Strings.isNullOrEmpty(defaultProjectId)) {
+          items.add(new Option(defaultProjectId, defaultProjectId, true));
+        } else {
+          // Select not the first (empty) item but the second item, which exists because
+          // projects is not empty.
+          items.get(1).selected = true;
         }
         return items;
       } catch (IOException ioe) {

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -379,6 +379,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
       }
     }
 
+    // TODO(stephenshank): Validate projectId against list of projects from CloudResourceManagerClient
     public FormValidation doCheckProjectId(@QueryParameter("projectId") String projectId) {
       if (Strings.isNullOrEmpty(projectId)) {
         return FormValidation.error(Messages.KubernetesEnginePublisher_ProjectIDRequired());

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -337,7 +337,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
         @AncestorInPath Jenkins context,
         @QueryParameter("credentialsId") final String credentialsId) {
       ListBoxModel items = new ListBoxModel();
-      items.add("");
+      items.add("- none -");
       if (Strings.isNullOrEmpty(credentialsId)) {
         return items;
       }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -75,7 +75,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
   private String clusterName;
   private String credentialsId;
   private String zone;
-  private String entryMethod;
+  private String zoneEntry;
   private String projectIdEntry;
   private String manifestPattern;
   private boolean verifyDeployments;
@@ -123,14 +123,14 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
     this.manifestPattern = manifestPattern;
   }
 
-  public String getEntryMethod() {
-    return this.entryMethod;
+  public String getZoneEntry() {
+    return this.zoneEntry;
   }
 
   @DataBoundSetter
-  public void setEntryMethod(String entryMethod) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(entryMethod));
-    this.entryMethod = entryMethod;
+  public void setZoneEntry(String zoneEntry) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(zoneEntry));
+    this.zoneEntry = zoneEntry;
   }
 
   public String getProjectIdEntry() {

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher.java
@@ -365,7 +365,7 @@ public class KubernetesEnginePublisher extends Notifier implements SimpleBuildSt
               .stream()
               .filter(p -> !p.getProjectId().equals(defaultProjectId))
               .forEach(p -> items.add(p.getProjectId()));
-          if (projects.size() > items.size() - 1) {
+          if (projects.size() > items.size() - 1 && !Strings.isNullOrEmpty(defaultProjectId)) {
             items.add(new Option(defaultProjectId, defaultProjectId, true));
           } else {
             // Select not the first (empty) item but the second item, which exists because

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
@@ -47,12 +47,16 @@ public class ClientFactory {
   private final Credential credential;
   private final HttpTransport transport;
   private final JsonFactory jsonFactory;
+  private final String credentialsId;
+  private final String defaultProjectId;
 
   @VisibleForTesting
   ClientFactory() throws AbortException {
     credential = null;
     transport = null;
     jsonFactory = null;
+    defaultProjectId = null;
+    credentialsId = null;
   }
 
   /**
@@ -91,6 +95,8 @@ public class ClientFactory {
       throw new AbortException(
           Messages.ClientFactory_FailedToInitializeHTTPTransport(gse.getMessage()));
     }
+    defaultProjectId = robotCreds.getProjectId();
+    this.credentialsId = credentialsId;
 
     try {
       this.transport = httpTransport.orElse(GoogleNetHttpTransport.newTrustedTransport());
@@ -180,6 +186,14 @@ public class ClientFactory {
             .setApplicationName(APPLICATION_NAME)
             .setCloudResourceManagerRequestInitializer(new CloudResourceManagerRequestInitializer())
             .build());
+  }
+
+  public String getDefaultProjectId() {
+    return this.defaultProjectId;
+  }
+
+  public String getCredentialsId() {
+    return this.credentialsId;
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
@@ -95,7 +95,8 @@ public class ClientFactory {
       throw new AbortException(
           Messages.ClientFactory_FailedToInitializeHTTPTransport(gse.getMessage()));
     }
-    defaultProjectId = robotCreds.getProjectId();
+    this.defaultProjectId =
+        Strings.isNullOrEmpty(robotCreds.getProjectId()) ? "" : robotCreds.getProjectId();
     this.credentialsId = credentialsId;
 
     try {
@@ -115,7 +116,7 @@ public class ClientFactory {
    * @param itemGroup A handle to the Jenkins instance.
    * @param credentialsId The ID of the GoogleRobotCredentials to be retrieved from Jenkins and
    *     utilized for authorization.
-   * @throws AbortException
+   * @throws AbortException If failed to create a new client factory.
    */
   public ClientFactory(ItemGroup itemGroup, String credentialsId) throws AbortException {
     this(itemGroup, ImmutableList.of(), credentialsId, Optional.empty());
@@ -188,10 +189,12 @@ public class ClientFactory {
             .build());
   }
 
+  /** @return The default Project ID associated with this ClientFactory's credentials. */
   public String getDefaultProjectId() {
     return this.defaultProjectId;
   }
 
+  /** @return The Credentials ID for this ClientFactory. */
   public String getCredentialsId() {
     return this.credentialsId;
   }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -19,6 +19,7 @@ package com.google.jenkins.plugins.k8sengine.client;
 import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -58,6 +59,6 @@ public class CloudResourceManagerClient {
     // Sort by project ID
     projects.sort(Comparator.comparing(Project::getProjectId));
 
-    return projects;
+    return ImmutableList.copyOf(projects);
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -1,0 +1,47 @@
+package com.google.jenkins.plugins.k8sengine.client;
+
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Client for communicating with the Google Cloud Research Manager API.
+ *
+ * @see <a href="https://cloud.google.com/resource-manager/reference/rest/">Cloud Research Manager
+ *     API</a>
+ */
+public class CloudResourceManagerClient {
+  private final CloudResourceManager cloudResourceManager;
+
+  /**
+   * Constructs a new {@link CloudResourceManagerClient} instance.
+   *
+   * @param cloudResourceManager The {@link CloudResourceManager} instance this class will utilize
+   *     for interacting with the Cloud Resource Manager API.
+   */
+  public CloudResourceManagerClient(CloudResourceManager cloudResourceManager) {
+    this.cloudResourceManager = Preconditions.checkNotNull(cloudResourceManager);
+  }
+
+  /**
+   * Retrieves a list of Projects for the credentials associated with this client.
+   *
+   * @return The retrieved list of projects
+   * @throws IOException When an error occurred attempting to get the projects.
+   */
+  public List<Project> getAccountProjects() throws IOException {
+    List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
+    if (projects == null) {
+      projects = new ArrayList<>();
+    }
+
+    // Sort by project ID
+    projects.sort(Comparator.comparing(Project::getProjectId));
+
+    return projects;
+  }
+}

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.k8sengine.client;
 
 import com.google.api.services.cloudresourcemanager.CloudResourceManager;

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -17,6 +17,7 @@ package com.google.jenkins.plugins.k8sengine.client;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Zone;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -58,6 +59,6 @@ public class ComputeClient {
     // Sort by name
     zones.sort(Comparator.comparing(Zone::getName));
 
-    return zones;
+    return ImmutableList.copyOf(zones);
   }
 }

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
@@ -5,12 +5,12 @@
        <c:select/>
     </f:entry>
     <f:section title="${%Zone}">
-        <f:radioBlock name="entryMethod" title="Dropdown" value="dropdown" checked="true" inline="true">
+        <f:radioBlock name="zoneEntry" title="Dropdown" value="dropdown" checked="true" inline="true">
             <f:entry field="zone">
                 <f:select/>
             </f:entry>
         </f:radioBlock>
-        <f:radioBlock name="entryMethod" title="Textbox" value="textbox" inline="true">
+        <f:radioBlock name="zoneEntry" title="Textbox" value="textbox" inline="true">
             <f:entry field="zone">
                 <f:textbox/>
             </f:entry>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
@@ -1,11 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <f:entry field="projectId" title="${%Project ID}">
-        <f:textbox/>
-    </f:entry>
-    <f:entry field="clusterName" title="${%Cluster}">
-        <f:textbox/>
+    <f:entry field="credentialsId" title="${%Service Account Credentials}">
+       <c:select/>
     </f:entry>
     <f:section title="${%Zone}">
         <f:radioBlock name="entryMethod" title="Dropdown" value="dropdown" checked="true" inline="true">
@@ -19,12 +16,24 @@
             </f:entry>
         </f:radioBlock>
     </f:section>
+    <f:section title="${%Project ID}">
+        <f:radioBlock name="projectIdEntry" title="${%Dropdown}" value="dropdown" checked="true" inline="true">
+            <f:entry field="projectId">
+                <f:select checkMethod="post"/>
+            </f:entry>
+        </f:radioBlock>
+        <f:radioBlock name="projectIdEntry" title="${%Textbox}" value="textbox" inline="true">
+            <f:entry field="projectId">
+                <f:textbox/>
+            </f:entry>
+        </f:radioBlock>
+    </f:section>
+    <f:entry field="clusterName" title="${%Cluster}">
+        <f:textbox/>
+    </f:entry>
     <!-- TODO: look in drop-down button to select manifests from file selector -->
     <f:entry field="manifestPattern" title="${%Kubernetes Manifests}">
         <f:textbox/>
-    </f:entry>
-    <f:entry field="credentialsId" title="${%Service Account Credentials}">
-        <c:select/>
     </f:entry>
     <!-- TODO(craigatgoogle): re-enable once these QOL features are complete.
     <f:entry field="verifyDeployments" title="${%Verify Deployments}">

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
@@ -3,6 +3,7 @@ KubernetesEnginePublisher.ClusterRequired=Cluster is required
 KubernetesEnginePublisher.NamespaceRequired=Namespace is required
 KubernetesEnginePublisher.ManifestRequired=Manifest is required
 KubernetesEnginePublisher.ProjectIDRequired=Project ID is required
+KubernetesEnginePublisher.ProjectIDFillError=Error retrieving Project IDs from CloudResourceManager
 KubernetesEnginePublisher.NoCredential=No credential selected
 KubernetesEnginePublisher.CredentialProjectIDRequired=Project ID required to validate credential
 KubernetesEnginePublisher.CredentialAuthFailed=Credentials failed to authenticate

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -47,6 +47,7 @@ public class KubernetesEnginePublisherTest {
   private static final String OTHER_PROJECT_ID = "other-project-id";
   private static final String ERROR_PROJECT_ID = "error-project-id";
   private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
+  private static final String EMPTY_PROJECT_CREDENTIALS_ID = "empty-project-credentials-id";
   private static final String PROJECT_ERROR_CREDENTIALS_ID = "project-error-credentials-id";
   private static final String ERROR_CREDENTIALS_ID = "error-credentials-id";
   private static final String TEST_ERROR_MESSAGE = "error";
@@ -74,6 +75,14 @@ public class KubernetesEnginePublisherTest {
     Mockito.when(clientFactory.getDefaultProjectId()).thenReturn(TEST_PROJECT_ID);
     Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
     Mockito.doReturn(clientFactory).when(descriptor).getClientFactory(jenkins, TEST_CREDENTIALS_ID);
+
+    ClientFactory emptyProjectClientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.when(emptyProjectClientFactory.getDefaultProjectId()).thenReturn("");
+    Mockito.when(emptyProjectClientFactory.cloudResourceManagerClient())
+        .thenReturn(cloudResourceManagerClient);
+    Mockito.doReturn(emptyProjectClientFactory)
+        .when(descriptor)
+        .getClientFactory(jenkins, EMPTY_PROJECT_CREDENTIALS_ID);
 
     CloudResourceManagerClient errorCloudResourceManagerClient =
         Mockito.mock(CloudResourceManagerClient.class);
@@ -149,8 +158,10 @@ public class KubernetesEnginePublisherTest {
     assertEquals(3, projects.size());
     assertEquals("", projects.get(0).name);
     assertEquals("", projects.get(0).value);
+    assertFalse(projects.get(0).selected);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).value);
+    assertFalse(projects.get(1).selected);
     assertEquals(TEST_PROJECT_ID, projects.get(2).name);
     assertEquals(TEST_PROJECT_ID, projects.get(2).value);
     assertTrue(projects.get(2).selected);
@@ -164,9 +175,28 @@ public class KubernetesEnginePublisherTest {
     assertEquals(2, projects.size());
     assertEquals("", projects.get(0).name);
     assertEquals("", projects.get(0).value);
+    assertFalse(projects.get(0).selected);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).value);
     assertTrue(projects.get(1).selected);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsWithValidCredentialsAndEmptyProject() {
+    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
+    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, EMPTY_PROJECT_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(3, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+    assertFalse(projects.get(0).selected);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).value);
+    assertTrue(projects.get(1).selected);
+    assertEquals(TEST_PROJECT_ID, projects.get(2).name);
+    assertEquals(TEST_PROJECT_ID, projects.get(2).value);
+    assertFalse(projects.get(2).selected);
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -66,7 +66,6 @@ public class KubernetesEnginePublisherTest {
     ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     Mockito.when(computeClient.getZones(TEST_PROJECT_ID)).thenReturn(listOfZones);
     Mockito.when(computeClient.getZones(ERROR_PROJECT_ID)).thenThrow(new IOException());
-    Mockito.doReturn(computeClient).when(descriptor).getComputeClient(jenkins, TEST_CREDENTIALS_ID);
 
     CloudResourceManagerClient cloudResourceManagerClient =
         Mockito.mock(CloudResourceManagerClient.class);
@@ -74,6 +73,7 @@ public class KubernetesEnginePublisherTest {
     ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
     Mockito.when(clientFactory.getDefaultProjectId()).thenReturn(TEST_PROJECT_ID);
     Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
+    Mockito.when(clientFactory.computeClient()).thenReturn(computeClient);
     Mockito.doReturn(clientFactory).when(descriptor).getClientFactory(jenkins, TEST_CREDENTIALS_ID);
 
     ClientFactory emptyProjectClientFactory = Mockito.mock(ClientFactory.class);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -122,7 +122,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, PROJECT_ERROR_CREDENTIALS_ID);
     assertNotNull(projects);
     assertEquals(2, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
     assertFalse(projects.get(0).selected);
     assertEquals(ERROR_PROJECT_ID, projects.get(1).name);
@@ -136,7 +136,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, null);
     assertNotNull(projects);
     assertEquals(1, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
   }
 
@@ -145,7 +145,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
     assertNotNull(projects);
     assertEquals(1, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
   }
 
@@ -156,7 +156,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
     assertNotNull(projects);
     assertEquals(3, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
     assertFalse(projects.get(0).selected);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
@@ -173,7 +173,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
     assertNotNull(projects);
     assertEquals(2, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
     assertFalse(projects.get(0).selected);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
@@ -188,7 +188,7 @@ public class KubernetesEnginePublisherTest {
     ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, EMPTY_PROJECT_CREDENTIALS_ID);
     assertNotNull(projects);
     assertEquals(3, projects.size());
-    assertEquals("", projects.get(0).name);
+    assertEquals("- none -", projects.get(0).name);
     assertEquals("", projects.get(0).value);
     assertFalse(projects.get(0).selected);
     assertEquals(OTHER_PROJECT_ID, projects.get(1).name);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -15,12 +15,17 @@
 package com.google.jenkins.plugins.k8sengine;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.api.services.compute.model.Zone;
 import com.google.common.base.Strings;
+import com.google.jenkins.plugins.k8sengine.client.ClientFactory;
+import com.google.jenkins.plugins.k8sengine.client.CloudResourceManagerClient;
 import com.google.jenkins.plugins.k8sengine.client.ComputeClient;
+import hudson.AbortException;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
@@ -39,27 +44,129 @@ public class KubernetesEnginePublisherTest {
   private static final String TEST_ZONE_A = "us-west1-a";
   private static final String TEST_ZONE_B = "us-west1-b";
   private static final String TEST_PROJECT_ID = "test-project-id";
+  private static final String OTHER_PROJECT_ID = "other-project-id";
   private static final String ERROR_PROJECT_ID = "error-project-id";
   private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
+  private static final String PROJECT_ERROR_CREDENTIALS_ID = "project-error-credentials-id";
+  private static final String ERROR_CREDENTIALS_ID = "error-credentials-id";
+  private static final String TEST_ERROR_MESSAGE = "error";
 
   private static List<Zone> listOfZones;
+  private static List<Project> listOfProjects;
   private static Jenkins jenkins;
-  private KubernetesEnginePublisher.DescriptorImpl descriptor;
+  private static KubernetesEnginePublisher.DescriptorImpl descriptor;
 
   @BeforeClass
   public static void init() throws IOException {
     listOfZones = new ArrayList<>();
+    listOfProjects = new ArrayList<>();
+    descriptor = Mockito.spy(KubernetesEnginePublisher.DescriptorImpl.class);
+    jenkins = Mockito.mock(Jenkins.class);
     ComputeClient computeClient = Mockito.mock(ComputeClient.class);
     Mockito.when(computeClient.getZones(TEST_PROJECT_ID)).thenReturn(listOfZones);
     Mockito.when(computeClient.getZones(ERROR_PROJECT_ID)).thenThrow(new IOException());
-    KubernetesEnginePublisher.DescriptorImpl.setComputeClient(computeClient);
-    jenkins = Mockito.mock(Jenkins.class);
+    Mockito.doReturn(computeClient).when(descriptor).getComputeClient(jenkins, TEST_CREDENTIALS_ID);
+
+    CloudResourceManagerClient cloudResourceManagerClient =
+        Mockito.mock(CloudResourceManagerClient.class);
+    Mockito.when(cloudResourceManagerClient.getAccountProjects()).thenReturn(listOfProjects);
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.when(clientFactory.getDefaultProjectId()).thenReturn(TEST_PROJECT_ID);
+    Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
+    Mockito.doReturn(clientFactory).when(descriptor).getClientFactory(jenkins, TEST_CREDENTIALS_ID);
+
+    CloudResourceManagerClient errorCloudResourceManagerClient =
+        Mockito.mock(CloudResourceManagerClient.class);
+    Mockito.when(errorCloudResourceManagerClient.getAccountProjects()).thenThrow(new IOException());
+    ClientFactory projectErrorClientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.when(projectErrorClientFactory.getDefaultProjectId()).thenReturn(ERROR_PROJECT_ID);
+    Mockito.when(projectErrorClientFactory.cloudResourceManagerClient())
+        .thenReturn(errorCloudResourceManagerClient);
+    Mockito.doReturn(projectErrorClientFactory)
+        .when(descriptor)
+        .getClientFactory(jenkins, PROJECT_ERROR_CREDENTIALS_ID);
+
+    Mockito.doThrow(new AbortException(TEST_ERROR_MESSAGE))
+        .when(descriptor)
+        .getClientFactory(jenkins, ERROR_CREDENTIALS_ID);
   }
 
   @Before
   public void before() {
     listOfZones.clear();
-    descriptor = new KubernetesEnginePublisher.DescriptorImpl();
+    listOfProjects.clear();
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsErrorMessageWithAbortException() {
+    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, ERROR_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(1, projects.size());
+    assertEquals(TEST_ERROR_MESSAGE, projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsDefaultProjectIdWithIOException() {
+    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, PROJECT_ERROR_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(2, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+    assertFalse(projects.get(0).selected);
+    assertEquals(ERROR_PROJECT_ID, projects.get(1).name);
+    assertEquals(ERROR_PROJECT_ID, projects.get(1).value);
+    assertTrue(projects.get(1).selected);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsEmptyWithEmptyCredentialsId() {
+    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, null);
+    assertNotNull(projects);
+    assertEquals(1, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsEmptyWithValidCredentialsIdNoProjects() {
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(1, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsWithValidCredentialsId() {
+    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(3, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).value);
+    assertEquals(TEST_PROJECT_ID, projects.get(2).name);
+    assertEquals(TEST_PROJECT_ID, projects.get(2).value);
+    assertTrue(projects.get(2).selected);
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsWithValidCredentialsIdNoDefaultProject() {
+    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
+    ListBoxModel projects = descriptor.doFillProjectIdItems(jenkins, TEST_CREDENTIALS_ID);
+    assertNotNull(projects);
+    assertEquals(2, projects.size());
+    assertEquals("", projects.get(0).name);
+    assertEquals("", projects.get(0).value);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).name);
+    assertEquals(OTHER_PROJECT_ID, projects.get(1).value);
+    assertTrue(projects.get(1).selected);
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientFactoryTest.java
@@ -91,5 +91,6 @@ public class ClientFactoryTest {
             Optional.<HttpTransport>empty());
     Assert.assertNotNull(cf.containerClient());
     Assert.assertNotNull(cf.computeClient());
+    Assert.assertNotNull(cf.cloudResourceManagerClient());
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
@@ -1,0 +1,136 @@
+package com.google.jenkins.plugins.k8sengine.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.services.cloudresourcemanager.CloudResourceManager;
+import com.google.api.services.cloudresourcemanager.CloudResourceManager.Projects;
+import com.google.api.services.cloudresourcemanager.model.ListProjectsResponse;
+import com.google.api.services.cloudresourcemanager.model.Project;
+import hudson.AbortException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudResourceManagerClientTest {
+  private static final String TEST_CREDENTIALS_ID = "test-credentials";
+  private static final String ERROR_CREDENTIALS_ID = "error-credentials";
+  private static final List<String> TEST_PROJECT_IDS_SORTED =
+      Arrays.asList("test-project-id-a1", "test-project-id-a2", "test-project-id-a3");
+  private static final List<String> TEST_PROJECT_IDS_UNSORTED =
+      Arrays.asList("test-project-id-b4", "test-project-id-b2", "test-project-id-b5");
+
+  private static List<Project> listOfProjects;
+  private static Jenkins jenkins;
+  private static ClientFactory clientFactorySpy;
+
+  @BeforeClass
+  public static void init() throws IOException {
+    listOfProjects = new ArrayList<>();
+
+    CloudResourceManager cloudResourceManager = Mockito.mock(CloudResourceManager.class);
+    Projects projects = Mockito.mock(Projects.class);
+    Projects.List listProjects = Mockito.mock(Projects.List.class);
+    ListProjectsResponse listProjectsResponse = Mockito.mock(ListProjectsResponse.class);
+    Mockito.when(cloudResourceManager.projects()).thenReturn(projects);
+    Mockito.when(projects.list()).thenReturn(listProjects);
+    Mockito.when(listProjects.execute()).thenReturn(listProjectsResponse);
+    Mockito.when(listProjectsResponse.getProjects()).thenReturn(listOfProjects);
+    CloudResourceManagerClient client = new CloudResourceManagerClient(cloudResourceManager);
+
+    CloudResourceManager errorCloudResourceManager = Mockito.mock(CloudResourceManager.class);
+    Projects errorProjects = Mockito.mock(Projects.class);
+    Projects.List errorListProjects = Mockito.mock(Projects.List.class);
+    Mockito.when(errorCloudResourceManager.projects()).thenReturn(errorProjects);
+    Mockito.when(errorProjects.list()).thenReturn(errorListProjects);
+    Mockito.when(errorListProjects.execute()).thenThrow(new IOException());
+    CloudResourceManagerClient errorClient =
+        new CloudResourceManagerClient(errorCloudResourceManager);
+
+    // Credentials are passed in at the time of creation.
+    jenkins = Mockito.mock(Jenkins.class);
+    clientFactorySpy = Mockito.spy(ClientFactory.class);
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    ClientFactory errorClientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(client);
+    Mockito.when(errorClientFactory.cloudResourceManagerClient()).thenReturn(errorClient);
+    Mockito.doReturn(clientFactory)
+        .when(clientFactorySpy)
+        .makeClientFactory(jenkins, TEST_CREDENTIALS_ID);
+    Mockito.doReturn(errorClientFactory)
+        .when(clientFactorySpy)
+        .makeClientFactory(jenkins, ERROR_CREDENTIALS_ID);
+  }
+
+  @Before
+  public void before() {
+    listOfProjects.clear();
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetAccountProjectsErrorWithInvalidCredentials() throws IOException {
+    testGetProjects(ERROR_CREDENTIALS_ID, Collections.emptyList());
+  }
+
+  @Test
+  public void testGetAccountProjectsEmptyReturnsEmpty() throws IOException {
+    testGetProjects(TEST_CREDENTIALS_ID, Collections.emptyList());
+  }
+
+  @Test
+  public void testGetAccountProjectsSorted() throws IOException {
+    fillListOfProjects(TEST_PROJECT_IDS_SORTED);
+    testGetProjects(TEST_CREDENTIALS_ID, TEST_PROJECT_IDS_SORTED);
+  }
+
+  @Test
+  public void testGetAccountProjectsUnsortedReturnedAsSorted() throws IOException {
+    fillListOfProjects(TEST_PROJECT_IDS_UNSORTED);
+    testGetProjects(TEST_CREDENTIALS_ID, TEST_PROJECT_IDS_UNSORTED);
+  }
+
+  private static CloudResourceManagerClient getClient(String credentialsId) throws AbortException {
+    ClientFactory clientFactory = clientFactorySpy.makeClientFactory(jenkins, credentialsId);
+    return clientFactory.cloudResourceManagerClient();
+  }
+
+  private static void fillListOfProjects(List<String> projectIds) {
+    projectIds.forEach(id -> listOfProjects.add(new Project().setProjectId(id)));
+  }
+
+  private static void testGetProjects(String credentialsId, List<String> projectIds)
+      throws IOException {
+    CloudResourceManagerClient client = getClient(credentialsId);
+    List<String> expectedProjectIds = new ArrayList<>(projectIds);
+    List<Project> projects = client.getAccountProjects();
+    assertNotNull("projects was null.", projects);
+    assertEquals(
+        String.format(
+            "Excepted %d projects but %d projects retrieved.",
+            expectedProjectIds.size(), projects.size()),
+        expectedProjectIds.size(),
+        projects.size());
+
+    if (expectedProjectIds.size() > 0) {
+      expectedProjectIds.sort(String::compareTo);
+      for (int i = 0; i < expectedProjectIds.size(); i++) {
+        assertEquals(
+            String.format(
+                "Projects not sorted. Expected %s but was %s.",
+                expectedProjectIds.get(i), projects.get(i).getName()),
+            expectedProjectIds.get(i),
+            projects.get(i).getProjectId());
+      }
+    }
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.k8sengine.client;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Apologies for the PR size, I recommend looking by commit. The majority of this change is in testing, boilerplate, and a new client for retrieving the list of project IDs from the Cloud Resource Manager API.

The reason that this is a dropdown is that as far as I can tell it is not possible to do two crucial things:
1. Fill a f:textbox using query parameters and have that play nice with the Publisher.
2. Set up a new handler (i.e. onchange) for the c:select (credentials dropdown) tag when that is selected.

I suspect that doing this would require forgoing jelly altogether and writing our view a different way (i.e. JS/HTML/CSS, groovy).

I tried to minimize the impact that this change had on other elements of the KubernetesEnginePublisher and associated tests and view but I faced a few complications when testing, both through unit tests and in the browser:

1. When the credentialsId is selected, this then changes the "credentialsId" query parameter used when filling the project ID items. Unfortunately, the newly selected "projectId" query parameter is not then updated in the call to check credentialsId unless the credentialsId dropdown comes before projectId's

2. There is a similar story for Zone. The automatically selected "projectId" query paramater is not updated in both the call to fill zone items and to check zone, unless the Zone dropdown comes before the projectId dropdown.

3. The behavior of getComputeClient() in the descriptor is only technically correct in tests (before this change) because the descriptor is a new object for every test. In a future PR I will bring the usage of the ComputeClient in line with that of the CloudResourceManagerClient so that doFillZoneItems and doCheckZoneItems construct their ComputeClient using the ClientFactory from getClientFactory in the compute client.

4. In order to make a spy for ClientFactory in the CloudResourceManagerClientTest, I need both a zero argument constructor and a "makeClientFactory" method. The reason I need a spy is that unlike the ComputeClient, the only arguments involved are passed through the constructor of ClientFactory (the credentialsId), that then allows me to mock the behavior of listing service account projects depending on the value of the CredentialsId.