### PR TITLE
[Incremental] JENKINS-55523: Refactor entry of ProjectId and Zone selection to dropdowns only

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
@@ -4,11 +4,11 @@
     <f:entry field="credentialsId" title="${%Service Account Credentials}">
        <c:select/>
     </f:entry>
-    <f:entry field="zone" title="${%Zone}">
-        <f:textbox/>
-    </f:entry>
     <f:entry field="projectId" title="${%Project ID}">
-        <f:textbox/>
+        <f:select/>
+    </f:entry>
+    <f:entry field="zone" title="${%Zone}">
+        <f:select/>
     </f:entry>
     <f:entry field="clusterName" title="${%Cluster}">
         <f:textbox/>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisher/config.jelly
@@ -4,30 +4,12 @@
     <f:entry field="credentialsId" title="${%Service Account Credentials}">
        <c:select/>
     </f:entry>
-    <f:section title="${%Zone}">
-        <f:radioBlock name="zoneEntry" title="Dropdown" value="dropdown" checked="true" inline="true">
-            <f:entry field="zone">
-                <f:select/>
-            </f:entry>
-        </f:radioBlock>
-        <f:radioBlock name="zoneEntry" title="Textbox" value="textbox" inline="true">
-            <f:entry field="zone">
-                <f:textbox/>
-            </f:entry>
-        </f:radioBlock>
-    </f:section>
-    <f:section title="${%Project ID}">
-        <f:radioBlock name="projectIdEntry" title="${%Dropdown}" value="dropdown" checked="true" inline="true">
-            <f:entry field="projectId">
-                <f:select checkMethod="post"/>
-            </f:entry>
-        </f:radioBlock>
-        <f:radioBlock name="projectIdEntry" title="${%Textbox}" value="textbox" inline="true">
-            <f:entry field="projectId">
-                <f:textbox/>
-            </f:entry>
-        </f:radioBlock>
-    </f:section>
+    <f:entry field="zone" title="${%Zone}">
+        <f:textbox/>
+    </f:entry>
+    <f:entry field="projectId" title="${%Project ID}">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="clusterName" title="${%Cluster}">
         <f:textbox/>
     </f:entry>

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -122,6 +122,15 @@ public class KubernetesEnginePublisherTest {
   }
 
   @Test
+  public void testDoAutoCompleteProjectIdWithNullProjectId() {
+    testProjectAutoComplete(
+        null,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_PROJECT_ID, OTHER_PROJECT_ID),
+        ImmutableList.of(TEST_PROJECT_ID, OTHER_PROJECT_ID));
+  }
+
+  @Test
   public void testDoAutoCompleteProjectIdDefaultOnlyWithValidCredentialsIdNoProjects() {
     testProjectAutoComplete(
         "", TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of(TEST_PROJECT_ID));
@@ -152,6 +161,33 @@ public class KubernetesEnginePublisherTest {
         EMPTY_PROJECT_CREDENTIALS_ID,
         ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
         ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
+  }
+
+  @Test
+  public void testDoAutoCompleteProjectIdEmptyWithNoMatching() {
+    testProjectAutoComplete(
+        "h",
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testDoAutoCompleteProjectIdEmptyWithPartialMatching() {
+    testProjectAutoComplete(
+        "test-not",
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testDoAutoCompleteProjectIdFiltersWithNonMatchingProjectId() {
+    testProjectAutoComplete(
+        "other-",
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of(OTHER_PROJECT_ID));
   }
 
   @Test
@@ -235,6 +271,16 @@ public class KubernetesEnginePublisherTest {
   }
 
   @Test
+  public void testDoAutoCompleteZoneWithNullZone() {
+    testZoneAutoComplete(
+        null,
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B));
+  }
+
+  @Test
   public void testDoAutoCompleteZoneEmptyWithValidArgumentsNoZones() {
     testZoneAutoComplete(
         "", TEST_PROJECT_ID, TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of());
@@ -244,6 +290,36 @@ public class KubernetesEnginePublisherTest {
   public void testDoAutoCompleteZoneEmptyWithIOException() {
     testZoneAutoComplete(
         "", ERROR_PROJECT_ID, TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of());
+  }
+
+  @Test
+  public void testDoAutoCompleteZoneEmptyWithNoMatching() {
+    testZoneAutoComplete(
+        "eur",
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testDoAutoCompleteZoneEmptyWithPartialMatching() {
+    testZoneAutoComplete(
+        "us-e",
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void testDoAutoCompleteZoneFiltersNonMatchingZone() {
+    testZoneAutoComplete(
+        "us-c",
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of(TEST_ZONE_B));
   }
 
   @Test

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -40,7 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesEnginePublisherTest {
   private static final String TEST_ZONE_A = "us-west1-a";
-  private static final String TEST_ZONE_B = "us-west1-b";
+  private static final String TEST_ZONE_B = "us-central1-b";
   private static final String TEST_PROJECT_ID = "test-project-id";
   private static final String OTHER_PROJECT_ID = "other-project-id";
   private static final String ERROR_PROJECT_ID = "error-project-id";
@@ -106,55 +106,52 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdEmptyWithAbortException() {
-    initProjects(ImmutableList.of(TEST_PROJECT_ID));
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", ERROR_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(), projects);
+    testProjectAutoComplete(
+        "", ERROR_CREDENTIALS_ID, ImmutableList.of(TEST_PROJECT_ID), ImmutableList.of());
   }
 
   @Test
   public void testDoAutoCompleteProjectIdDefaultProjectIdWithIOException() {
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", PROJECT_ERROR_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(ERROR_PROJECT_ID), projects);
+    testProjectAutoComplete(
+        "", PROJECT_ERROR_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of(ERROR_PROJECT_ID));
   }
 
   @Test
   public void testDoAutoCompleteProjectIdEmptyWithEmptyCredentialsId() {
-    initProjects(ImmutableList.of(TEST_PROJECT_ID));
-    AutoCompletionCandidates projects = descriptor.doAutoCompleteProjectId(jenkins, "", null);
-    testAutoCompleteResult(ImmutableList.of(), projects);
+    testProjectAutoComplete("", null, ImmutableList.of(TEST_PROJECT_ID), ImmutableList.of());
   }
 
   @Test
   public void testDoAutoCompleteProjectIdDefaultOnlyWithValidCredentialsIdNoProjects() {
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(TEST_PROJECT_ID), projects);
+    testProjectAutoComplete(
+        "", TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of(TEST_PROJECT_ID));
   }
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsId() {
-    initProjects(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(TEST_PROJECT_ID, OTHER_PROJECT_ID), projects);
+    testProjectAutoComplete(
+        "",
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of(TEST_PROJECT_ID, OTHER_PROJECT_ID));
   }
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsIdNoDefaultProject() {
-    initProjects(ImmutableList.of(OTHER_PROJECT_ID));
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), projects);
+    testProjectAutoComplete(
+        "",
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID),
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
   }
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsAndEmptyProject() {
-    initProjects(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    AutoCompletionCandidates projects =
-        descriptor.doAutoCompleteProjectId(jenkins, "", EMPTY_PROJECT_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), projects);
+    testProjectAutoComplete(
+        "",
+        EMPTY_PROJECT_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
   }
 
   @Test
@@ -217,40 +214,36 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithEmptyProjectId() {
-    initZones(ImmutableList.of(TEST_ZONE_A));
-    AutoCompletionCandidates zones =
-        descriptor.doAutoCompleteZone(jenkins, "", null, TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(), zones);
+    testZoneAutoComplete(
+        "", null, TEST_CREDENTIALS_ID, ImmutableList.of(TEST_ZONE_A), ImmutableList.of());
   }
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithEmptyCredentialsId() {
-    initZones(ImmutableList.of(TEST_ZONE_A));
-    AutoCompletionCandidates zones =
-        descriptor.doAutoCompleteZone(jenkins, "", TEST_PROJECT_ID, null);
-    testAutoCompleteResult(ImmutableList.of(), zones);
+    testZoneAutoComplete(
+        "", TEST_PROJECT_ID, null, ImmutableList.of(TEST_ZONE_A), ImmutableList.of());
   }
 
   @Test
   public void testDoAutoCompleteZoneWithValidArguments() {
-    initZones(ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B));
-    AutoCompletionCandidates zones =
-        descriptor.doAutoCompleteZone(jenkins, "", TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B), zones);
+    testZoneAutoComplete(
+        "",
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B));
   }
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithValidArgumentsNoZones() {
-    AutoCompletionCandidates zones =
-        descriptor.doAutoCompleteZone(jenkins, "", TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(), zones);
+    testZoneAutoComplete(
+        "", TEST_PROJECT_ID, TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of());
   }
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithIOException() {
-    AutoCompletionCandidates zones =
-        descriptor.doAutoCompleteZone(jenkins, "", ERROR_PROJECT_ID, TEST_CREDENTIALS_ID);
-    testAutoCompleteResult(ImmutableList.of(), zones);
+    testZoneAutoComplete(
+        "", ERROR_PROJECT_ID, TEST_CREDENTIALS_ID, ImmutableList.of(), ImmutableList.of());
   }
 
   @Test
@@ -315,11 +308,30 @@ public class KubernetesEnginePublisherTest {
     zoneNames.forEach(z -> listOfZones.add(new Zone().setName(z)));
   }
 
-  private static void initProjects(List<String> projectIds) {
-    projectIds.forEach(p -> listOfProjects.add(new Project().setProjectId(p)));
+  private static void initProjects(List<String> projectNames) {
+    projectNames.forEach(p -> listOfProjects.add(new Project().setProjectId(p)));
   }
 
-  private static void testAutoCompleteResult(List<String> expected, AutoCompletionCandidates items) {
+  private static void testZoneAutoComplete(
+      String zone,
+      String projectId,
+      String credentialsId,
+      List<String> init,
+      List<String> expected) {
+    initZones(init);
+    testAutoCompleteResult(
+        expected, descriptor.doAutoCompleteZone(jenkins, zone, projectId, credentialsId));
+  }
+
+  private static void testProjectAutoComplete(
+      String projectId, String credentialsId, List<String> init, List<String> expected) {
+    initProjects(init);
+    testAutoCompleteResult(
+        expected, descriptor.doAutoCompleteProjectId(jenkins, projectId, credentialsId));
+  }
+
+  private static void testAutoCompleteResult(
+      List<String> expected, AutoCompletionCandidates items) {
     assertNotNull(items);
     List<String> values = items.getValues();
     assertNotNull(values);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEnginePublisherTest.java
@@ -106,7 +106,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdEmptyWithAbortException() {
-    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    initProjects(ImmutableList.of(TEST_PROJECT_ID));
     AutoCompletionCandidates projects =
         descriptor.doAutoCompleteProjectId(jenkins, "", ERROR_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(), projects);
@@ -121,7 +121,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdEmptyWithEmptyCredentialsId() {
-    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    initProjects(ImmutableList.of(TEST_PROJECT_ID));
     AutoCompletionCandidates projects = descriptor.doAutoCompleteProjectId(jenkins, "", null);
     testAutoCompleteResult(ImmutableList.of(), projects);
   }
@@ -135,8 +135,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsId() {
-    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
-    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    initProjects(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
     AutoCompletionCandidates projects =
         descriptor.doAutoCompleteProjectId(jenkins, "", TEST_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(TEST_PROJECT_ID, OTHER_PROJECT_ID), projects);
@@ -144,7 +143,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsIdNoDefaultProject() {
-    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
+    initProjects(ImmutableList.of(OTHER_PROJECT_ID));
     AutoCompletionCandidates projects =
         descriptor.doAutoCompleteProjectId(jenkins, "", TEST_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), projects);
@@ -152,8 +151,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteProjectIdWithValidCredentialsAndEmptyProject() {
-    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
-    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    initProjects(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID));
     AutoCompletionCandidates projects =
         descriptor.doAutoCompleteProjectId(jenkins, "", EMPTY_PROJECT_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), projects);
@@ -202,7 +200,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoCheckProjectIdMessageWithWrongProjects() {
-    listOfProjects.add(new Project().setProjectId(OTHER_PROJECT_ID));
+    initProjects(ImmutableList.of(OTHER_PROJECT_ID));
     FormValidation result =
         descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertEquals(
@@ -211,7 +209,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoCheckProjectIdMessageWithValidProject() {
-    listOfProjects.add(new Project().setProjectId(TEST_PROJECT_ID));
+    initProjects(ImmutableList.of(TEST_PROJECT_ID));
     FormValidation result =
         descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertEquals(FormValidation.ok().getMessage(), result.getMessage());
@@ -219,7 +217,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithEmptyProjectId() {
-    listOfZones.add(new Zone().setName(TEST_ZONE_A));
+    initZones(ImmutableList.of(TEST_ZONE_A));
     AutoCompletionCandidates zones =
         descriptor.doAutoCompleteZone(jenkins, "", null, TEST_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(), zones);
@@ -227,7 +225,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteZoneEmptyWithEmptyCredentialsId() {
-    listOfZones.add(new Zone().setName(TEST_ZONE_A));
+    initZones(ImmutableList.of(TEST_ZONE_A));
     AutoCompletionCandidates zones =
         descriptor.doAutoCompleteZone(jenkins, "", TEST_PROJECT_ID, null);
     testAutoCompleteResult(ImmutableList.of(), zones);
@@ -235,8 +233,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoAutoCompleteZoneWithValidArguments() {
-    listOfZones.add(new Zone().setName(TEST_ZONE_A));
-    listOfZones.add(new Zone().setName(TEST_ZONE_B));
+    initZones(ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B));
     AutoCompletionCandidates zones =
         descriptor.doAutoCompleteZone(jenkins, "", TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     testAutoCompleteResult(ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B), zones);
@@ -290,7 +287,7 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoCheckZoneMessageWithNonMatchingZones() {
-    listOfZones.add(new Zone().setName(TEST_ZONE_B));
+    initZones(ImmutableList.of(TEST_ZONE_B));
     FormValidation result =
         descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertNotNull(result);
@@ -307,14 +304,22 @@ public class KubernetesEnginePublisherTest {
 
   @Test
   public void testDoCheckZoneOKWithMatchingZones() {
-    listOfZones.add(new Zone().setName(TEST_ZONE_A));
+    initZones(ImmutableList.of(TEST_ZONE_A));
     FormValidation result =
         descriptor.doCheckZone(jenkins, TEST_ZONE_A, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
     assertNotNull(result);
     assertEquals(FormValidation.ok(), result);
   }
 
-  private void testAutoCompleteResult(List<String> expected, AutoCompletionCandidates items) {
+  private static void initZones(List<String> zoneNames) {
+    zoneNames.forEach(z -> listOfZones.add(new Zone().setName(z)));
+  }
+
+  private static void initProjects(List<String> projectIds) {
+    projectIds.forEach(p -> listOfProjects.add(new Project().setProjectId(p)));
+  }
+
+  private static void testAutoCompleteResult(List<String> expected, AutoCompletionCandidates items) {
     assertNotNull(items);
     List<String> values = items.getValues();
     assertNotNull(values);


### PR DESCRIPTION
This also has some unit test refactors that made testing these new changes a lot easier. Unfortunately, this does not actually accomplish auto-completion in the UI in its current form because the query parameters that are needed are not being sent when the text boxes are updated. I posted about this on Jenkins Developers, so hopefully I get some help there. Wanted to get this out there before the weekend, because if the autocomplete doesn't work I can modify this to be purely a dropdown.