### PR TITLE
[Incremental] JENKINS-55523: Make Cluster Name a dropdown and autofill available cluster.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -227,6 +227,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
 
     public ListBoxModel doFillClusterNameItems(
         @AncestorInPath Jenkins context,
+        @QueryParameter("clusterName") final String clusterName,
         @QueryParameter("credentialsId") final String credentialsId,
         @QueryParameter("projectId") final String projectId,
         @QueryParameter("zone") final String zone) {
@@ -257,7 +258,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
         }
 
         clusters.forEach(c -> items.add(c.getName()));
-        items.get(1).selected = true;
+        selectOption(items, clusterName);
         return items;
       } catch (IOException ioe) {
         LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ClusterFillError(), ioe);
@@ -285,8 +286,9 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
 
     public ListBoxModel doFillZoneItems(
         @AncestorInPath Jenkins context,
-        @QueryParameter("projectId") String projectId,
-        @QueryParameter("credentialsId") String credentialsId) {
+        @QueryParameter("zone") final String zone,
+        @QueryParameter("projectId") final String projectId,
+        @QueryParameter("credentialsId") final String credentialsId) {
       ListBoxModel items = new ListBoxModel();
       items.add(EMPTY_NAME, EMPTY_VALUE);
       if (Strings.isNullOrEmpty(projectId) || Strings.isNullOrEmpty(credentialsId)) {
@@ -312,7 +314,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
         }
 
         zones.forEach(z -> items.add(z.getName()));
-        items.get(1).selected = true;
+        selectOption(items, zone);
         return items;
       } catch (IOException ioe) {
         LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ZoneFillError(), ioe);
@@ -358,6 +360,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
 
     public ListBoxModel doFillProjectIdItems(
         @AncestorInPath Jenkins context,
+        @QueryParameter("projectId") final String projectId,
         @QueryParameter("credentialsId") final String credentialsId) {
       ListBoxModel items = new ListBoxModel();
       items.add(EMPTY_NAME, EMPTY_VALUE);
@@ -390,7 +393,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
             .forEach(p -> items.add(p.getProjectId()));
 
         if (Strings.isNullOrEmpty(defaultProjectId)) {
-          items.get(1).selected = true;
+          selectOption(items, projectId);
           return items;
         }
 
@@ -399,7 +402,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
         } else {
           // Add defaultProjectId anyway, but select the first available item.
           items.add(defaultProjectId);
-          items.get(1).selected = true;
+          selectOption(items, projectId);
         }
         return items;
       } catch (IOException ioe) {
@@ -477,6 +480,17 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
 
       return FormValidation.ok();
     }
+  }
+
+  private static void selectOption(ListBoxModel listBoxModel, String optionValue) {
+    Optional<Option> item;
+    if (Strings.isNullOrEmpty(optionValue)) {
+      item =
+          listBoxModel.stream().filter(option -> !Strings.isNullOrEmpty(option.value)).findFirst();
+    } else {
+      item = listBoxModel.stream().filter(option -> optionValue.equals(option.value)).findFirst();
+    }
+    item.ifPresent(i -> i.selected = true);
   }
 
   private static ContainerClient getContainerClient(String credentialsId) throws AbortException {

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -397,10 +397,11 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
           return items;
         }
 
-        if (projects.size() == items.size()) {
+        if (projects.size() == items.size() && Strings.isNullOrEmpty(projectId)) {
           items.add(new Option(defaultProjectId, defaultProjectId, true));
         } else {
-          // Add defaultProjectId anyway, but select the first available item.
+          // Add defaultProjectId anyway, but select the appropriate projectID based on
+          // the previously entered projectID
           items.add(defaultProjectId);
           selectOption(items, projectId);
         }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -21,7 +21,6 @@ import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -53,7 +52,7 @@ public class CloudResourceManagerClient {
   public List<Project> getAccountProjects() throws IOException {
     List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
     if (projects == null) {
-      projects = new ArrayList<>();
+      projects = ImmutableList.of();
     }
 
     // Sort by project ID

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -19,7 +19,6 @@ import com.google.api.services.compute.model.Zone;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -53,7 +52,7 @@ public class ComputeClient {
     Preconditions.checkNotNull(projectId);
     List<Zone> zones = compute.zones().list(projectId).execute().getItems();
     if (zones == null) {
-      zones = new ArrayList<>();
+      zones = ImmutableList.of();
     }
 
     // Sort by name

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
@@ -18,7 +18,10 @@ import com.google.api.services.container.Container;
 import com.google.api.services.container.model.Cluster;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Client for communicating with the Google GKE API.
@@ -42,9 +45,9 @@ public class ContainerClient {
   /**
    * Retrieves a {@link Cluster} from the container client.
    *
-   * @param projectId The ID of the project the clusters reside in.
-   * @param zone The location of the clusters.
-   * @param cluster The name of the cluster b
+   * @param projectId The ID of the project the cluster resides in.
+   * @param zone The location of the cluster.
+   * @param cluster The name of the cluster.
    * @return The retrieved {@link Cluster}.
    * @throws IOException When an error occurred attempting to get the cluster.
    */
@@ -53,5 +56,25 @@ public class ContainerClient {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(zone));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
     return container.projects().zones().clusters().get(projectId, zone, cluster).execute();
+  }
+
+  /**
+   * Retrieves a list of {@link Cluster} objects from the container client.
+   *
+   * @param projectId The ID of the project the clusters resides
+   * @param zone The location of the clusters.
+   * @return The retrieved list of {@link Cluster} objects.
+   * @throws IOException When an error occurred attempting to get the cluster.
+   */
+  public List<Cluster> listClusters(String projectId, String zone) throws IOException {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(zone));
+    List<Cluster> clusters =
+        container.projects().zones().clusters().list(projectId, zone).execute().getClusters();
+    if (clusters == null) {
+      return ImmutableList.of();
+    }
+    clusters.sort(Comparator.comparing(Cluster::getName));
+    return ImmutableList.copyOf(clusters);
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
@@ -61,7 +61,7 @@ public class ContainerClient {
   /**
    * Retrieves a list of {@link Cluster} objects from the container client.
    *
-   * @param projectId The ID of the project the clusters resides
+   * @param projectId The ID of the project the clusters resides.
    * @param zone The location of the clusters.
    * @return The retrieved list of {@link Cluster} objects.
    * @throws IOException When an error occurred attempting to get the cluster.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
@@ -11,7 +11,7 @@
         <f:select/>
     </f:entry>
     <f:entry field="clusterName" title="${%Cluster}">
-        <f:textbox/>
+        <f:select/>
     </f:entry>
     <!-- TODO: look in drop-down button to select manifests from file selector -->
     <f:entry field="manifestPattern" title="${%Kubernetes Manifests}">

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
@@ -1,5 +1,6 @@
 KubernetesEngineBuilder.DisplayName=Google Kubernetes Engine
 KubernetesEngineBuilder.ClusterRequired=Cluster is required
+KubernetesEngineBuilder.ClusterFillError=Error retrieving clusters from GKE
 KubernetesEngineBuilder.NamespaceRequired=Namespace is required
 KubernetesEngineBuilder.ManifestRequired=Manifest is required
 KubernetesEngineBuilder.ProjectIDRequired=Project ID is required

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -126,6 +126,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillProjectIdItemsErrorMessageWithAbortException() {
     testDoFillProjectIDItems(
+        null,
         ERROR_CREDENTIALS_ID,
         ImmutableList.of(TEST_PROJECT_ID),
         null,
@@ -136,6 +137,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillProjectIdItemsErrorMessageWithIOException() {
     testDoFillProjectIDItems(
+        null,
         PROJECT_ERROR_CREDENTIALS_ID,
         ImmutableList.of(),
         null,
@@ -147,6 +149,7 @@ public class KubernetesEngineBuilderTest {
   public void testDoFillProjectIdItemsEmptyWithEmptyCredentialsId() {
     testDoFillProjectIDItems(
         null,
+        null,
         ImmutableList.of(TEST_PROJECT_ID),
         null,
         ImmutableList.of(EMPTY_NAME),
@@ -156,6 +159,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillProjectIdItemsEmptyWithEmptyCredentialsIdNoProjects() {
     testDoFillProjectIDItems(
+        null,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(),
         null,
@@ -166,6 +170,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillProjectIdItemsWithValidCredentialsId() {
     testDoFillProjectIDItems(
+        null,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
         TEST_PROJECT_ID,
@@ -174,8 +179,31 @@ public class KubernetesEngineBuilderTest {
   }
 
   @Test
+  public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndDefault() {
+    testDoFillProjectIDItems(
+        OTHER_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        OTHER_PROJECT_ID,
+        ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+  }
+
+  @Test
+  public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndEmptyDefault() {
+    testDoFillProjectIDItems(
+        OTHER_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        OTHER_PROJECT_ID,
+        ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+        ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+  }
+
+  @Test
   public void testDoFillProjectIdItemsWithValidCredentialsIdNoDefaultProject() {
     testDoFillProjectIDItems(
+        null,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(OTHER_PROJECT_ID),
         OTHER_PROJECT_ID,
@@ -186,6 +214,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillProjectIdItemsWithValidCredentialsAndEmptyProject() {
     testDoFillProjectIDItems(
+        null,
         EMPTY_PROJECT_CREDENTIALS_ID,
         ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID),
         OTHER_PROJECT_ID,
@@ -255,6 +284,7 @@ public class KubernetesEngineBuilderTest {
   public void testDoFillZoneItemsEmptyWithEmptyProjectId() {
     testDoFillZoneItems(
         null,
+        null,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(TEST_ZONE_A),
         null,
@@ -265,6 +295,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillZoneItemsEmptyWithEmptyCredentialsId() {
     testDoFillZoneItems(
+        null,
         TEST_PROJECT_ID,
         null,
         ImmutableList.of(TEST_ZONE_A),
@@ -276,6 +307,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillZoneItemsWithValidArguments() {
     testDoFillZoneItems(
+        null,
         TEST_PROJECT_ID,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
@@ -285,8 +317,21 @@ public class KubernetesEngineBuilderTest {
   }
 
   @Test
+  public void testDoFillZoneItemsWithValidArgumentsAndPreviousValue() {
+    testDoFillZoneItems(
+        TEST_ZONE_B,
+        TEST_PROJECT_ID,
+        TEST_CREDENTIALS_ID,
+        ImmutableList.of(TEST_ZONE_A, TEST_ZONE_B),
+        TEST_ZONE_B,
+        ImmutableList.of(EMPTY_NAME, TEST_ZONE_A, TEST_ZONE_B),
+        ImmutableList.of(EMPTY_VALUE, TEST_ZONE_A, TEST_ZONE_B));
+  }
+
+  @Test
   public void testDoFillZoneItemsEmptyWithValidArgumentsNoZones() {
     testDoFillZoneItems(
+        null,
         TEST_PROJECT_ID,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(),
@@ -298,6 +343,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillZoneItemsErrorMessageWithAbortException() {
     testDoFillZoneItems(
+        null,
         TEST_PROJECT_ID,
         ERROR_CREDENTIALS_ID,
         ImmutableList.of(),
@@ -309,6 +355,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillZoneItemsErrorMessageWithIOException() {
     testDoFillZoneItems(
+        null,
         ERROR_PROJECT_ID,
         TEST_CREDENTIALS_ID,
         ImmutableList.of(),
@@ -379,6 +426,7 @@ public class KubernetesEngineBuilderTest {
   public void testDoFillClusterNameItemsEmptyWithEmptyCredentialsId() {
     testDoFillClusterNameItems(
         null,
+        null,
         TEST_PROJECT_ID,
         TEST_ZONE_A,
         ImmutableList.of(TEST_CLUSTER),
@@ -390,6 +438,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsEmptyWithEmptyProjectId() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         null,
         TEST_ZONE_A,
@@ -402,6 +451,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsEmptyWithEmptyZone() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         TEST_PROJECT_ID,
         null,
@@ -414,6 +464,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsErrorMessageWithAbortException() {
     testDoFillClusterNameItems(
+        null,
         ERROR_CREDENTIALS_ID,
         TEST_PROJECT_ID,
         TEST_ZONE_A,
@@ -426,6 +477,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsEmptyWithValidInputsNoClusters() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         TEST_PROJECT_ID,
         TEST_ZONE_A,
@@ -438,6 +490,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsWithValidInputsOneCluster() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         TEST_PROJECT_ID,
         TEST_ZONE_A,
@@ -450,6 +503,7 @@ public class KubernetesEngineBuilderTest {
   @Test
   public void testDoFillClusterNameItemsWithValidInputsMultipleClusters() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         TEST_PROJECT_ID,
         TEST_ZONE_A,
@@ -460,8 +514,22 @@ public class KubernetesEngineBuilderTest {
   }
 
   @Test
+  public void testDoFillClusterNameItemsWithValidInputsAndPreviousValue() {
+    testDoFillClusterNameItems(
+        TEST_CLUSTER,
+        TEST_CREDENTIALS_ID,
+        TEST_PROJECT_ID,
+        TEST_ZONE_A,
+        ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER),
+        TEST_CLUSTER,
+        ImmutableList.of(EMPTY_NAME, OTHER_CLUSTER, TEST_CLUSTER),
+        ImmutableList.of(EMPTY_VALUE, OTHER_CLUSTER, TEST_CLUSTER));
+  }
+
+  @Test
   public void testDoFillClusterNameItemsErrorMessageWithIOException() {
     testDoFillClusterNameItems(
+        null,
         TEST_CREDENTIALS_ID,
         ERROR_PROJECT_ID,
         TEST_ZONE_A,
@@ -484,6 +552,7 @@ public class KubernetesEngineBuilderTest {
   }
 
   private static void testDoFillZoneItems(
+      String zone,
       String projectId,
       String credentialsId,
       List<String> init,
@@ -495,10 +564,11 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillZoneItems(jenkins, null, projectId, credentialsId));
+        descriptor.doFillZoneItems(jenkins, zone, projectId, credentialsId));
   }
 
   private static void testDoFillProjectIDItems(
+      String projectId,
       String credentialsId,
       List<String> init,
       String expectedSelected,
@@ -515,10 +585,11 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillProjectIdItems(jenkins, null, credentialsId));
+        descriptor.doFillProjectIdItems(jenkins, projectId, credentialsId));
   }
 
   private static void testDoFillClusterNameItems(
+      String clusterName,
       String credentialsId,
       String projectId,
       String zone,
@@ -532,7 +603,7 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillClusterNameItems(jenkins, null, credentialsId, projectId, zone));
+        descriptor.doFillClusterNameItems(jenkins, clusterName, credentialsId, projectId, zone));
   }
 
   private static void testFillItemsResult(

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -495,7 +495,7 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillZoneItems(jenkins, projectId, credentialsId));
+        descriptor.doFillZoneItems(jenkins, null, projectId, credentialsId));
   }
 
   private static void testDoFillProjectIDItems(
@@ -515,7 +515,7 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillProjectIdItems(jenkins, credentialsId));
+        descriptor.doFillProjectIdItems(jenkins, null, credentialsId));
   }
 
   private static void testDoFillClusterNameItems(
@@ -532,7 +532,7 @@ public class KubernetesEngineBuilderTest {
         expectedNames,
         expectedValues,
         expectedSelected,
-        descriptor.doFillClusterNameItems(jenkins, credentialsId, projectId, zone));
+        descriptor.doFillClusterNameItems(jenkins, null, credentialsId, projectId, zone));
   }
 
   private static void testFillItemsResult(

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -16,108 +16,188 @@ package com.google.jenkins.plugins.k8sengine.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import com.google.api.services.container.Container;
+import com.google.api.services.container.Container.Projects.Zones.Clusters;
 import com.google.api.services.container.model.Cluster;
+import com.google.api.services.container.model.ListClustersResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 /** Tests {@link ContainerClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerClientTest {
-  private ContainerClient containerClient;
-  @Mock private Container.Projects.Zones.Clusters clusters;
+  private static final String TEST_PROJECT_ID = "test-project-id";
+  private static final String OTHER_PROJECT_ID = "other-project-id";
+  private static final String ERROR_PROJECT_ID = "error-project-id";
+  private static final String EMPTY_PROJECT_ID = "empty-project-id";
+  private static final String TEST_ZONE = "us-west1-a";
+  private static final String OTHER_ZONE = "us-west2-b";
+  private static final String TEST_CLUSTER = "testCluster";
+  private static final String OTHER_CLUSTER = "otherCluster";
 
-  @Before
-  public void init() throws Exception {
+  private static ContainerClient containerClient;
+  private static Cluster testCluster;
+  private static Cluster otherCluster;
+
+  @BeforeClass
+  public static void init() throws Exception {
     Container container = Mockito.mock(Container.class);
-    ;
     Container.Projects projects = Mockito.mock(Container.Projects.class);
     Container.Projects.Zones zones = Mockito.mock(Container.Projects.Zones.class);
+    Clusters clusters = Mockito.mock(Container.Projects.Zones.Clusters.class);
     Mockito.when(container.projects()).thenReturn(projects);
     Mockito.when(projects.zones()).thenReturn(zones);
     Mockito.when(zones.clusters()).thenReturn(clusters);
-    this.containerClient = new ContainerClient(container);
+    testCluster = new Cluster().setName(TEST_CLUSTER).setZone(TEST_ZONE);
+    otherCluster = new Cluster().setName(OTHER_CLUSTER).setZone(TEST_ZONE);
+
+    Mockito.when(clusters.get(anyString(), anyString(), anyString()))
+        .thenAnswer(
+            mockClustersGetAnswer(
+                new ImmutableMap.Builder<String, ImmutableList<Cluster>>()
+                    .put(TEST_PROJECT_ID, ImmutableList.of(testCluster))
+                    .build()));
+
+    Mockito.when(clusters.list(anyString(), anyString()))
+        .thenAnswer(
+            mockClustersListAnswer(
+                new ImmutableMap.Builder<Pair<String, String>, ImmutableList<Cluster>>()
+                    .put(
+                        ImmutablePair.of(TEST_PROJECT_ID, TEST_ZONE), ImmutableList.of(testCluster))
+                    .put(
+                        ImmutablePair.of(OTHER_PROJECT_ID, TEST_ZONE),
+                        ImmutableList.of(otherCluster))
+                    .put(ImmutablePair.of(EMPTY_PROJECT_ID, TEST_ZONE), ImmutableList.of())
+                    .build()));
+    containerClient = new ContainerClient(container);
   }
 
   @Test
-  public void testGetClusterReturnsProperlyWhenClusterExists() throws Exception {
-    Cluster testCluster = new Cluster();
-    testCluster.setName("testCluster");
-    testCluster.setZone("us-central1-c");
-    Mockito.when(clusters.get(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
-        .thenAnswer(
-            mockClustersGetAnswer(
-                new ImmutableMap.Builder<String, ImmutableList<Cluster>>()
-                    .put("testProject", ImmutableList.<Cluster>of(testCluster))
-                    .build()));
-
-    Cluster response = containerClient.getCluster("testProject", "us-central1-c", "testCluster");
+  public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
+    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, "testCluster");
     assertNotNull(response);
-    assertEquals(response, testCluster);
+    assertEquals(testCluster, response);
   }
 
   @Test(expected = IOException.class)
-  public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws Exception {
-    Cluster testCluster = new Cluster();
-    testCluster.setName("testCluster");
-    testCluster.setZone("us-central1-c");
-    Mockito.when(clusters.get(Matchers.anyString(), Matchers.anyString(), Matchers.anyString()))
-        .thenAnswer(
-            mockClustersGetAnswer(
-                new ImmutableMap.Builder<String, ImmutableList<Cluster>>()
-                    .put("testProject", ImmutableList.<Cluster>of(testCluster))
-                    .build()));
-
-    containerClient.getCluster("testProject", "us-central-c", "otherCluster");
+  public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
+    containerClient.getCluster(TEST_PROJECT_ID, OTHER_ZONE, "otherCluster");
   }
 
-  private Answer<Container.Projects.Zones.Clusters.Get> mockClustersGetAnswer(
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithNullProjectId() throws IOException {
+    testListClusters(null, TEST_ZONE, ImmutableList.of());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithNullZone() throws IOException {
+    testListClusters(TEST_PROJECT_ID, null, ImmutableList.of());
+  }
+
+  @Test
+  public void testListClustersWithValidInputsWhenClustersExist() throws IOException {
+    testListClusters(TEST_PROJECT_ID, TEST_ZONE, ImmutableList.of(TEST_CLUSTER));
+  }
+
+  @Test
+  public void testListClustersWithDifferentProjectClusters() throws IOException {
+    testListClusters(OTHER_PROJECT_ID, TEST_ZONE, ImmutableList.of(OTHER_CLUSTER));
+  }
+
+  @Test
+  public void testListClustersWithValidInputsWhenClustersIsNull() throws IOException {
+    testListClusters(OTHER_PROJECT_ID, OTHER_ZONE, ImmutableList.of());
+  }
+
+  @Test
+  public void testListClustersEmptyWithValidProjectWithNoClusters() throws IOException {
+    testListClusters(EMPTY_PROJECT_ID, TEST_ZONE, ImmutableList.of());
+  }
+
+  @Test(expected = IOException.class)
+  public void testListClustersThrowsErrorWithInvalidProject() throws IOException {
+    testListClusters(ERROR_PROJECT_ID, TEST_ZONE, ImmutableList.of());
+  }
+
+  private static void testListClusters(String projectId, String zone, List<String> expected)
+      throws IOException {
+    List<Cluster> clusters = new ArrayList<>();
+    expected.forEach(e -> clusters.add(new Cluster().setName(e).setZone(TEST_ZONE)));
+    List<Cluster> response = containerClient.listClusters(projectId, zone);
+    assertNotNull(response);
+    assertEquals(ImmutableList.copyOf(clusters), response);
+  }
+
+  private static Answer<Container.Projects.Zones.Clusters.Get> mockClustersGetAnswer(
       ImmutableMap<String, ImmutableList<Cluster>> projectToClusters) {
-    return new Answer<Container.Projects.Zones.Clusters.Get>() {
-      @Override
-      public Container.Projects.Zones.Clusters.Get answer(InvocationOnMock invocation)
-          throws IOException {
-        Object[] args = invocation.getArguments();
-        String projectId = (String) args[0];
-        String zone = (String) args[1];
-        String clusterName = (String) args[2];
-        if (!projectToClusters.containsKey(projectId)) {
-          throw new IOException(
-              String.format(
-                  "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
-                  projectId, zone, clusterName));
-        }
-
-        Optional<Cluster> cluster =
-            projectToClusters
-                .get(projectId)
-                .stream()
-                .filter(c -> c.getName().equals(clusterName) && c.getZone().equals(zone))
-                .findFirst();
-        if (!cluster.isPresent()) {
-          throw new IOException(
-              String.format(
-                  "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
-                  projectId, zone, clusterName));
-        }
-
-        Container.Projects.Zones.Clusters.Get getCall =
-            Mockito.mock(Container.Projects.Zones.Clusters.Get.class);
-        Mockito.when(getCall.execute()).thenReturn(cluster.get());
-        return getCall;
+    return invocation -> {
+      Object[] args = invocation.getArguments();
+      String projectId = (String) args[0];
+      String zone = (String) args[1];
+      String clusterName = (String) args[2];
+      if (!projectToClusters.containsKey(projectId)) {
+        throw new IOException(
+            String.format(
+                "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
+                projectId, zone, clusterName));
       }
+
+      Optional<Cluster> cluster =
+          projectToClusters
+              .get(projectId)
+              .stream()
+              .filter(c -> c.getName().equals(clusterName) && c.getZone().equals(zone))
+              .findFirst();
+      if (!cluster.isPresent()) {
+        throw new IOException(
+            String.format(
+                "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
+                projectId, zone, clusterName));
+      }
+
+      Container.Projects.Zones.Clusters.Get getCall =
+          Mockito.mock(Container.Projects.Zones.Clusters.Get.class);
+      Mockito.when(getCall.execute()).thenReturn(cluster.get());
+      return getCall;
+    };
+  }
+
+  private static Answer<Container.Projects.Zones.Clusters.List> mockClustersListAnswer(
+      ImmutableMap<Pair<String, String>, ImmutableList<Cluster>> projectToClusters) {
+    return invocation -> {
+      Object[] args = invocation.getArguments();
+      String projectId = (String) args[0];
+      String zone = (String) args[1];
+      Pair<String, String> parent = ImmutablePair.of(projectId, zone);
+
+      List<Cluster> clusters = null;
+      if (projectToClusters.containsKey(parent)) {
+        clusters = new ArrayList<>(projectToClusters.get(parent));
+      } else if (ERROR_PROJECT_ID.equals(projectId)) {
+        throw new IOException(
+            String.format(
+                "Failed to get clusters for projectId: %s and zone: %s", projectId, zone));
+      }
+
+      Container.Projects.Zones.Clusters.List listCall =
+          Mockito.mock(Container.Projects.Zones.Clusters.List.class);
+      ListClustersResponse response = new ListClustersResponse().setClusters(clusters);
+      Mockito.when(listCall.execute()).thenReturn(response);
+      return listCall;
     };
   }
 }


### PR DESCRIPTION
I'm glad I finished #11 before this because that made this change a lot less complicated, especially when it comes to testing.

With how it works now, the happy path is that the user chooses a credential, which causes the default project id to be chosen automatically, which causes the first available zone to be chosen automatically. It doesn't seem to filter this down to zones where the user has resources at the moment, but if the user then selects the correct zone, the first available cluster name is selected.

Assigned myself to the TODO for verification which will come in the next PR.