### PR TITLE
JENKINS-55532: Reduce compiler warnings.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -439,7 +439,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
 
   private static ContainerClient getContainerClient(String credentialsId) throws AbortException {
     return new ClientFactory(
-            Jenkins.getInstance(),
+            Jenkins.get(),
             ImmutableList.<DomainRequirement>of(),
             credentialsId,
             Optional.<HttpTransport>empty())

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
@@ -113,10 +113,9 @@ public class KubeConfigTest {
 
   private static boolean yamlEquals(String expectedYaml, String testYaml) throws IOException {
     Yaml yaml = new Yaml(new SafeConstructor());
-    Map<String, Object> testConfig =
-        (Map<String, Object>) yaml.load(new BufferedReader(new StringReader(testYaml)));
+    Map<String, Object> testConfig = yaml.load(new BufferedReader(new StringReader(testYaml)));
     Map<String, Object> expectedConfig =
-        (Map<String, Object>) yaml.load(new BufferedReader(new StringReader(expectedYaml)));
+        yaml.load(new BufferedReader(new StringReader(expectedYaml)));
 
     TriFunction<TriFunction, Object, Object, Boolean> deepCollectionEquals =
         (f, expected, test) -> {
@@ -125,10 +124,15 @@ public class KubeConfigTest {
           }
 
           if (expected instanceof Map) {
+            @SuppressWarnings("unchecked")
             Map<String, Object> expectedMap = (Map<String, Object>) expected;
+            @SuppressWarnings("unchecked")
             Map<String, Object> testMap = (Map<String, Object>) test;
             for (String key : expectedMap.keySet()) {
-              if (!(Boolean) f.apply(f, expectedMap.get(key), testMap.get(key))) {
+
+              @SuppressWarnings("unchecked")
+              Object result = f.apply(f, expectedMap.get(key), testMap.get(key));
+              if (!(Boolean) result) {
                 return false;
               }
             }
@@ -142,7 +146,9 @@ public class KubeConfigTest {
                 return false;
               }
 
-              if (!(Boolean) f.apply(f, expectedItr.next(), testItr.next())) {
+              @SuppressWarnings("unchecked")
+              Object result = f.apply(f, expectedItr.next(), testItr.next());
+              if (!(Boolean) result) {
                 return false;
               }
             }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/StringJsonServiceAccountConfig.java
@@ -76,7 +76,7 @@ public class StringJsonServiceAccountConfig extends ServiceAccountConfig {
   public com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.DescriptorImpl
       getDescriptor() {
     return (com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.DescriptorImpl)
-        Jenkins.getInstance()
+        Jenkins.get()
             .getDescriptorOrDie(
                 com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig.class);
   }


### PR DESCRIPTION
The ContainerClientTest warnings are resolved in #12. Also, there is a deprecated usage in a plugin that we are transitively dependent on: "maven-antrun-plugin".