### PR TITLE
#27: Remove shared mutable state from tests

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
@@ -19,8 +19,6 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
-import com.google.api.client.googleapis.services.GoogleClientRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
@@ -28,7 +26,6 @@ import com.google.api.services.cloudresourcemanager.CloudResourceManager;
 import com.google.api.services.cloudresourcemanager.CloudResourceManagerRequestInitializer;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.container.Container;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -49,15 +46,6 @@ public class ClientFactory {
   private final JsonFactory jsonFactory;
   private final String credentialsId;
   private final String defaultProjectId;
-
-  @VisibleForTesting
-  ClientFactory() throws AbortException {
-    credential = null;
-    transport = null;
-    jsonFactory = null;
-    defaultProjectId = null;
-    credentialsId = null;
-  }
 
   /**
    * Creates a {@link ClientFactory} instance.
@@ -131,14 +119,9 @@ public class ClientFactory {
     return new ContainerClient(
         new Container.Builder(transport, jsonFactory, credential)
             .setGoogleClientRequestInitializer(
-                new GoogleClientRequestInitializer() {
-                  @Override
-                  public void initialize(AbstractGoogleClientRequest<?> request)
-                      throws IOException {
+                request ->
                     request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME));
-                  }
-                })
+                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME)))
             .setHttpRequestInitializer(new RetryHttpInitializerWrapper(credential))
             .setApplicationName(APPLICATION_NAME)
             .build());
@@ -153,14 +136,9 @@ public class ClientFactory {
     return new ComputeClient(
         new Compute.Builder(transport, jsonFactory, credential)
             .setGoogleClientRequestInitializer(
-                new GoogleClientRequestInitializer() {
-                  @Override
-                  public void initialize(AbstractGoogleClientRequest<?> request)
-                      throws IOException {
+                request ->
                     request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME));
-                  }
-                })
+                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME)))
             .setHttpRequestInitializer(new RetryHttpInitializerWrapper(credential))
             .setApplicationName(APPLICATION_NAME)
             .build());
@@ -176,14 +154,9 @@ public class ClientFactory {
         new CloudResourceManager.Builder(
                 transport, jsonFactory, new RetryHttpInitializerWrapper(credential))
             .setGoogleClientRequestInitializer(
-                new GoogleClientRequestInitializer() {
-                  @Override
-                  public void initialize(AbstractGoogleClientRequest<?> request)
-                      throws IOException {
+                request ->
                     request.setRequestHeaders(
-                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME));
-                  }
-                })
+                        request.getRequestHeaders().setUserAgent(APPLICATION_NAME)))
             .setApplicationName(APPLICATION_NAME)
             .setCloudResourceManagerRequestInitializer(new CloudResourceManagerRequestInitializer())
             .build());
@@ -197,10 +170,5 @@ public class ClientFactory {
   /** @return The Credentials ID for this ClientFactory. */
   public String getCredentialsId() {
     return this.credentialsId;
-  }
-
-  @VisibleForTesting
-  ClientFactory makeClientFactory(ItemGroup itemGroup, String credentialsId) throws AbortException {
-    return new ClientFactory(itemGroup, credentialsId);
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -49,7 +49,7 @@ public class CloudResourceManagerClient {
    * @return The retrieved list of projects
    * @throws IOException When an error occurred attempting to get the projects.
    */
-  public List<Project> getAccountProjects() throws IOException {
+  public ImmutableList<Project> getAccountProjects() throws IOException {
     List<Project> projects = cloudResourceManager.projects().list().execute().getProjects();
     if (projects == null) {
       projects = ImmutableList.of();

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -48,7 +48,7 @@ public class ComputeClient {
    *     successful.
    * @throws IOException When an error occurred attempting to get the list of zones.
    */
-  public List<Zone> getZones(String projectId) throws IOException {
+  public ImmutableList<Zone> getZones(String projectId) throws IOException {
     Preconditions.checkNotNull(projectId);
     List<Zone> zones = compute.zones().list(projectId).execute().getItems();
     if (zones == null) {

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -17,6 +17,7 @@ package com.google.jenkins.plugins.k8sengine.client;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Zone;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Comparator;
@@ -41,7 +42,7 @@ public class ComputeClient {
   }
 
   /**
-   * Retrieves a list of {@link Zone} objects from the container client.
+   * Retrieves a list of {@link Zone} objects representing the zones in the project.
    *
    * @param projectId The ID of the project that zone usage is needed for.
    * @return The retrieved list of {@link Zone} objects. This will not be null if the request was
@@ -49,7 +50,7 @@ public class ComputeClient {
    * @throws IOException When an error occurred attempting to get the list of zones.
    */
   public ImmutableList<Zone> getZones(String projectId) throws IOException {
-    Preconditions.checkNotNull(projectId);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     List<Zone> zones = compute.zones().list(projectId).execute().getItems();
     if (zones == null) {
       zones = ImmutableList.of();

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -40,11 +40,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import jenkins.model.Jenkins;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -60,24 +58,9 @@ public class KubernetesEngineBuilderTest {
 
   private static Jenkins jenkins;
 
-  @Mock ClientFactory clientFactory;
-
-  @Mock CloudResourceManagerClient cloudResourceManagerClient;
-
-  @Mock ComputeClient computeClient;
-
-  @Mock ContainerClient containerClient;
-
   @BeforeClass
   public static void init() {
     jenkins = Mockito.mock(Jenkins.class);
-  }
-
-  @Before
-  public void before() {
-    Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
-    Mockito.when(clientFactory.computeClient()).thenReturn(computeClient);
-    Mockito.when(clientFactory.containerClient()).thenReturn(containerClient);
   }
 
   @Test
@@ -698,30 +681,30 @@ public class KubernetesEngineBuilderTest {
     assertEquals(Messages.KubernetesEngineBuilder_ClusterVerificationError(), result.getMessage());
   }
 
-  private DescriptorImpl setUpDescriptor(AbortException abortException) throws AbortException {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-    if (abortException != null) {
-      Mockito.doThrow(abortException)
-          .when(descriptor)
-          .getClientFactory(any(Jenkins.class), anyString());
-      return descriptor;
-    }
-    Mockito.doReturn(clientFactory)
-        .when(descriptor)
-        .getClientFactory(any(Jenkins.class), anyString());
-
-    return descriptor;
-  }
-
   private DescriptorImpl setUpProjectDescriptor(
       List<String> initialProjects,
       String defaultProjectId,
       AbortException abortException,
       IOException ioException)
       throws IOException {
-    DescriptorImpl descriptor = setUpDescriptor(abortException);
+    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+
+    if (abortException != null) {
+      Mockito.doThrow(abortException)
+          .when(descriptor)
+          .getClientFactory(any(Jenkins.class), anyString());
+      return descriptor;
+    }
+
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.doReturn(clientFactory)
+        .when(descriptor)
+        .getClientFactory(any(Jenkins.class), anyString());
 
     Mockito.when(clientFactory.getDefaultProjectId()).thenReturn(defaultProjectId);
+    CloudResourceManagerClient cloudResourceManagerClient =
+        Mockito.mock(CloudResourceManagerClient.class);
+    Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
 
     if (ioException != null) {
       Mockito.when(cloudResourceManagerClient.getAccountProjects()).thenThrow(ioException);
@@ -738,7 +721,22 @@ public class KubernetesEngineBuilderTest {
   private DescriptorImpl setUpZoneDescriptor(
       List<String> initialZones, AbortException abortException, IOException ioException)
       throws IOException {
-    DescriptorImpl descriptor = setUpDescriptor(abortException);
+    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+
+    if (abortException != null) {
+      Mockito.doThrow(abortException)
+          .when(descriptor)
+          .getClientFactory(any(Jenkins.class), anyString());
+      return descriptor;
+    }
+
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.doReturn(clientFactory)
+        .when(descriptor)
+        .getClientFactory(any(Jenkins.class), anyString());
+
+    ComputeClient computeClient = Mockito.mock(ComputeClient.class);
+    Mockito.when(clientFactory.computeClient()).thenReturn(computeClient);
 
     if (ioException != null) {
       Mockito.when(computeClient.getZones(anyString())).thenThrow(ioException);
@@ -754,7 +752,22 @@ public class KubernetesEngineBuilderTest {
   private DescriptorImpl setUpClusterDescriptor(
       List<String> initialClusters, AbortException abortException, IOException ioException)
       throws IOException {
-    DescriptorImpl descriptor = setUpDescriptor(abortException);
+    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+
+    if (abortException != null) {
+      Mockito.doThrow(abortException)
+          .when(descriptor)
+          .getClientFactory(any(Jenkins.class), anyString());
+      return descriptor;
+    }
+
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.doReturn(clientFactory)
+        .when(descriptor)
+        .getClientFactory(any(Jenkins.class), anyString());
+
+    ContainerClient containerClient = Mockito.mock(ContainerClient.class);
+    Mockito.when(clientFactory.containerClient()).thenReturn(containerClient);
 
     if (ioException != null) {
       Mockito.when(containerClient.listClusters(anyString(), anyString())).thenThrow(ioException);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
@@ -24,61 +24,32 @@ import com.google.api.services.cloudresourcemanager.CloudResourceManager.Project
 import com.google.api.services.cloudresourcemanager.model.ListProjectsResponse;
 import com.google.api.services.cloudresourcemanager.model.Project;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import hudson.AbortException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import jenkins.model.Jenkins;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudResourceManagerClientTest {
-  private static final String SORTED_CREDENTIALS_ID = "sorted-credentials";
-  private static final String UNSORTED_CREDENTIALS_ID = "unsorted-credentials";
-  private static final String EMPTY_CREDENTIALS_ID = "empty-credentials";
-  private static final String ERROR_CREDENTIALS_ID = "error-credentials";
-  private static final String NULL_CREDENTIALS_ID = "null-credentials";
   private static final List<String> TEST_PROJECT_IDS_SORTED =
       Arrays.asList("test-project-id-a1", "test-project-id-a2", "test-project-id-a3");
   private static final List<String> TEST_PROJECT_IDS_UNSORTED =
       Arrays.asList("test-project-id-b4", "test-project-id-b2", "test-project-id-b5");
 
-  private static Jenkins jenkins;
-  private static ClientFactory clientFactorySpy;
-
-  @BeforeClass
-  public static void init() throws IOException {
-    jenkins = Mockito.mock(Jenkins.class);
-    clientFactorySpy = Mockito.spy(ClientFactory.class);
-    Mockito.doAnswer(
-            mockClientFactoryAnswer(
-                new ImmutableMap.Builder<String, List<Project>>()
-                    .put(SORTED_CREDENTIALS_ID, initProjectList(TEST_PROJECT_IDS_SORTED))
-                    .put(UNSORTED_CREDENTIALS_ID, initProjectList(TEST_PROJECT_IDS_UNSORTED))
-                    .put(EMPTY_CREDENTIALS_ID, ImmutableList.of())
-                    .build()))
-        .when(clientFactorySpy)
-        .makeClientFactory(ArgumentMatchers.any(), ArgumentMatchers.anyString());
-  }
-
   @Test(expected = IOException.class)
   public void testGetAccountProjectsErrorWithInvalidCredentials() throws IOException {
-    CloudResourceManagerClient client = getClient(ERROR_CREDENTIALS_ID);
+    CloudResourceManagerClient client = setUpClient(null, new IOException());
     client.getAccountProjects();
   }
 
   @Test
   public void testGetAccountProjectsNullReturnsEmpty() throws IOException {
-    CloudResourceManagerClient client = getClient(NULL_CREDENTIALS_ID);
+    CloudResourceManagerClient client = setUpClient(null, null);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
@@ -86,7 +57,7 @@ public class CloudResourceManagerClientTest {
 
   @Test
   public void testGetAccountProjectsEmptyReturnsEmpty() throws IOException {
-    CloudResourceManagerClient client = getClient(EMPTY_CREDENTIALS_ID);
+    CloudResourceManagerClient client = setUpClient(ImmutableList.of(), null);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(ImmutableList.of(), projects);
@@ -94,7 +65,7 @@ public class CloudResourceManagerClientTest {
 
   @Test
   public void testGetAccountProjectsSorted() throws IOException {
-    CloudResourceManagerClient client = getClient(SORTED_CREDENTIALS_ID);
+    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_SORTED, null);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(initProjectList(TEST_PROJECT_IDS_SORTED), projects);
@@ -104,50 +75,37 @@ public class CloudResourceManagerClientTest {
   public void testGetAccountProjectsUnsortedReturnedAsSorted() throws IOException {
     List<Project> expected = initProjectList(TEST_PROJECT_IDS_UNSORTED);
     expected.sort(Comparator.comparing(Project::getProjectId));
-    CloudResourceManagerClient client = getClient(UNSORTED_CREDENTIALS_ID);
+    CloudResourceManagerClient client = setUpClient(TEST_PROJECT_IDS_UNSORTED, null);
     List<Project> projects = client.getAccountProjects();
     assertNotNull(projects);
     assertEquals(expected, projects);
   }
 
-  // Credentials are passed in when creating the ClientFactory, which makes this step necessary.
-  private static CloudResourceManagerClient getClient(String credentialsId) throws AbortException {
-    ClientFactory clientFactory = clientFactorySpy.makeClientFactory(jenkins, credentialsId);
-    return clientFactory.cloudResourceManagerClient();
+  private static CloudResourceManagerClient setUpClient(
+      List<String> initial, IOException ioException) throws IOException {
+    CloudResourceManager cloudResourceManager = Mockito.mock(CloudResourceManager.class);
+    Projects projects = Mockito.mock(Projects.class);
+    Mockito.when(cloudResourceManager.projects()).thenReturn(projects);
+    Projects.List projectsListCall = Mockito.mock(Projects.List.class);
+    Mockito.when(projects.list()).thenReturn(projectsListCall);
+
+    if (ioException != null) {
+      Mockito.when(projectsListCall.execute()).thenThrow(ioException);
+    } else if (initial == null) {
+      Mockito.when(projectsListCall.execute())
+          .thenReturn(new ListProjectsResponse().setProjects(null));
+    } else {
+      List<Project> projectList = initProjectList(initial);
+      Mockito.when(projectsListCall.execute())
+          .thenReturn(new ListProjectsResponse().setProjects(projectList));
+    }
+
+    return new CloudResourceManagerClient(cloudResourceManager);
   }
 
   private static List<Project> initProjectList(List<String> projectIds) {
     List<Project> projects = new ArrayList<>();
     projectIds.forEach(id -> projects.add(new Project().setProjectId(id)));
     return projects;
-  }
-
-  private static Answer<ClientFactory> mockClientFactoryAnswer(
-      ImmutableMap<String, List<Project>> credentialsIdToProjects) {
-    return invocation -> {
-      // Argument 0 is the Jenkins context.
-      String credentialsId = invocation.getArgument(1);
-
-      Projects.List projectsListCall = Mockito.mock(Projects.List.class);
-      if (credentialsIdToProjects.containsKey(credentialsId)) {
-        List<Project> projectsList = new ArrayList<>(credentialsIdToProjects.get(credentialsId));
-        Mockito.when(projectsListCall.execute())
-            .thenReturn(new ListProjectsResponse().setProjects(projectsList));
-      } else if (ERROR_CREDENTIALS_ID.equals(credentialsId)) {
-        Mockito.when(projectsListCall.execute()).thenThrow(new IOException());
-      } else {
-        Mockito.when(projectsListCall.execute())
-            .thenReturn(new ListProjectsResponse().setProjects(null));
-      }
-
-      CloudResourceManager cloudResourceManager = Mockito.mock(CloudResourceManager.class);
-      Projects projects = Mockito.mock(Projects.class);
-      Mockito.when(cloudResourceManager.projects()).thenReturn(projects);
-      Mockito.when(projects.list()).thenReturn(projectsListCall);
-      CloudResourceManagerClient client = new CloudResourceManagerClient(cloudResourceManager);
-      ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
-      Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(client);
-      return clientFactory;
-    };
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
@@ -16,12 +16,14 @@ package com.google.jenkins.plugins.k8sengine.client;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
 
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.Compute.Zones;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,47 +34,36 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 /** Test {@link ComputeClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ComputeClientTest {
   private static final String TEST_PROJECT_ID = "test-project";
+  private static final String OTHER_PROJECT_ID = "other-project";
   private static final String NULL_PROJECT_ID = "wrong-project";
   private static final String EMPTY_PROJECT_ID = "empty-project-id";
   private static final String ERROR_PROJECT_ID = "error-project-id";
+  private static final String TEST_ZONE_A = "us-central1-a";
+  private static final String TEST_ZONE_B = "us-west1-b";
+  private static final String TEST_ZONE_C = "us-east1-c";
   private static final List<String> ZONE_NAMES =
-      Arrays.asList("us-west-1b", "us-central-1a", "us-east-1c");
+      Arrays.asList(TEST_ZONE_B, TEST_ZONE_A, TEST_ZONE_C);
   private static ComputeClient computeClient;
 
   @BeforeClass
   public static void init() throws IOException {
-    List<Zone> listOfZones = initZoneList(ZONE_NAMES);
-    // Mock zones
     Compute compute = Mockito.mock(Compute.class);
-
     Zones zones = Mockito.mock(Zones.class);
-    Zones.List zonesListCall = Mockito.mock(Zones.List.class);
-    ZoneList zoneList = Mockito.mock(ZoneList.class);
     Mockito.when(compute.zones()).thenReturn(zones);
-    Mockito.when(zones.list(TEST_PROJECT_ID)).thenReturn(zonesListCall);
-    Mockito.when(zonesListCall.execute()).thenReturn(zoneList);
-    Mockito.when(zoneList.getItems()).thenReturn(listOfZones);
-
-    Zones.List nullZonesListCall = Mockito.mock(Zones.List.class);
-    ZoneList nullZoneList = Mockito.mock(ZoneList.class);
-    Mockito.when(zones.list(NULL_PROJECT_ID)).thenReturn(nullZonesListCall);
-    Mockito.when(nullZonesListCall.execute()).thenReturn(nullZoneList);
-    Mockito.when(nullZoneList.getItems()).thenReturn(null);
-
-    Zones.List emptyZonesListCall = Mockito.mock(Zones.List.class);
-    ZoneList emptyZoneList = Mockito.mock(ZoneList.class);
-    Mockito.when(zones.list(EMPTY_PROJECT_ID)).thenReturn(emptyZonesListCall);
-    Mockito.when(emptyZonesListCall.execute()).thenReturn(emptyZoneList);
-    Mockito.when(emptyZoneList.getItems()).thenReturn(ImmutableList.of());
-
-    Zones.List errorZonesListCall = Mockito.mock(Zones.List.class);
-    Mockito.when(zones.list(ERROR_PROJECT_ID)).thenReturn(errorZonesListCall);
-    Mockito.when(errorZonesListCall.execute()).thenThrow(new IOException());
+    Mockito.when(zones.list(anyString()))
+        .thenAnswer(
+            mockZonesListAnswer(
+                new ImmutableMap.Builder<String, List<Zone>>()
+                    .put(TEST_PROJECT_ID, initZoneList(ZONE_NAMES))
+                    .put(OTHER_PROJECT_ID, initZoneList(ImmutableList.of(TEST_ZONE_C)))
+                    .put(EMPTY_PROJECT_ID, ImmutableList.of())
+                    .build()));
     computeClient = new ComputeClient(compute);
   }
 
@@ -101,7 +92,14 @@ public class ComputeClientTest {
   }
 
   @Test
-  public void testGetZonesReturnsAllSortedWhenProjectIdCorrect() throws IOException {
+  public void testGetZonesReturnsWhenSingleZone() throws IOException {
+    List<Zone> zones = computeClient.getZones(OTHER_PROJECT_ID);
+    assertNotNull(zones);
+    assertEquals(initZoneList(ImmutableList.of(TEST_ZONE_C)), zones);
+  }
+
+  @Test
+  public void testGetZonesReturnsAllSortedWhenMultipleZones() throws IOException {
     List<Zone> expectedZones = initZoneList(ZONE_NAMES);
     expectedZones.sort(Comparator.comparing(Zone::getName));
     List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
@@ -113,5 +111,24 @@ public class ComputeClientTest {
     List<Zone> result = new ArrayList<>();
     names.forEach(z -> result.add(new Zone().setName(z)));
     return result;
+  }
+
+  private static Answer<Zones.List> mockZonesListAnswer(
+      ImmutableMap<String, List<Zone>> projectIdToZones) {
+    return invocation -> {
+      Object[] args = invocation.getArguments();
+      String projectId = (String) args[0];
+
+      Zones.List listCall = Mockito.mock(Zones.List.class);
+      if (projectIdToZones.containsKey(projectId)) {
+        List<Zone> zones = new ArrayList<>(projectIdToZones.get(projectId));
+        Mockito.when(listCall.execute()).thenReturn(new ZoneList().setItems(zones));
+      } else if (ERROR_PROJECT_ID.equals(projectId)) {
+        Mockito.when(listCall.execute()).thenThrow(new IOException());
+      } else {
+        Mockito.when(listCall.execute()).thenReturn(new ZoneList().setItems(null));
+      }
+      return listCall;
+    };
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
@@ -23,83 +23,66 @@ import com.google.api.services.compute.Compute.Zones;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 /** Test {@link ComputeClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ComputeClientTest {
   private static final String TEST_PROJECT_ID = "test-project";
-  private static final String OTHER_PROJECT_ID = "other-project";
-  private static final String NULL_PROJECT_ID = "wrong-project";
-  private static final String EMPTY_PROJECT_ID = "empty-project-id";
-  private static final String ERROR_PROJECT_ID = "error-project-id";
   private static final String TEST_ZONE_A = "us-central1-a";
   private static final String TEST_ZONE_B = "us-west1-b";
   private static final String TEST_ZONE_C = "us-east1-c";
   private static final List<String> ZONE_NAMES =
       Arrays.asList(TEST_ZONE_B, TEST_ZONE_A, TEST_ZONE_C);
-  private static ComputeClient computeClient;
-
-  @BeforeClass
-  public static void init() throws IOException {
-    Compute compute = Mockito.mock(Compute.class);
-    Zones zones = Mockito.mock(Zones.class);
-    Mockito.when(compute.zones()).thenReturn(zones);
-    Mockito.when(zones.list(anyString()))
-        .thenAnswer(
-            mockZonesListAnswer(
-                new ImmutableMap.Builder<String, List<Zone>>()
-                    .put(TEST_PROJECT_ID, initZoneList(ZONE_NAMES))
-                    .put(OTHER_PROJECT_ID, initZoneList(ImmutableList.of(TEST_ZONE_C)))
-                    .put(EMPTY_PROJECT_ID, ImmutableList.of())
-                    .build()));
-    computeClient = new ComputeClient(compute);
-  }
 
   @Test(expected = NullPointerException.class)
   public void testGetZonesExceptionWhenProjectIdNull() throws NullPointerException, IOException {
+    ComputeClient computeClient = setUpClient(null, null);
     computeClient.getZones(null);
   }
 
   @Test(expected = IOException.class)
   public void testGetZonesExceptionWhenIOException() throws IOException {
-    computeClient.getZones(ERROR_PROJECT_ID);
+    ComputeClient computeClient = setUpClient(null, new IOException());
+    computeClient.getZones(TEST_PROJECT_ID);
   }
 
   @Test
   public void testGetZonesReturnsEmptyWhenZoneListEmpty() throws IOException {
-    List<Zone> zones = computeClient.getZones(EMPTY_PROJECT_ID);
+    ComputeClient computeClient = setUpClient(ImmutableList.of(), null);
+    List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
     assertNotNull(zones);
     assertEquals(ImmutableList.of(), zones);
   }
 
   @Test
   public void testGetZonesReturnsEmptyWhenZoneListNull() throws IOException {
-    List<Zone> zones = computeClient.getZones(NULL_PROJECT_ID);
+    ComputeClient computeClient = setUpClient(null, null);
+    List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
     assertNotNull(zones);
     assertEquals(ImmutableList.of(), zones);
   }
 
   @Test
   public void testGetZonesReturnsWhenSingleZone() throws IOException {
-    List<Zone> zones = computeClient.getZones(OTHER_PROJECT_ID);
+    ComputeClient computeClient = setUpClient(ImmutableList.of(TEST_ZONE_C), null);
+    List<Zone> expectedZones = initZoneList(ImmutableList.of(TEST_ZONE_C));
+    List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
     assertNotNull(zones);
-    assertEquals(initZoneList(ImmutableList.of(TEST_ZONE_C)), zones);
+    assertEquals(expectedZones, zones);
   }
 
   @Test
   public void testGetZonesReturnsAllSortedWhenMultipleZones() throws IOException {
+    ComputeClient computeClient = setUpClient(ZONE_NAMES, null);
     List<Zone> expectedZones = initZoneList(ZONE_NAMES);
     expectedZones.sort(Comparator.comparing(Zone::getName));
     List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
@@ -113,22 +96,22 @@ public class ComputeClientTest {
     return result;
   }
 
-  private static Answer<Zones.List> mockZonesListAnswer(
-      ImmutableMap<String, List<Zone>> projectIdToZones) {
-    return invocation -> {
-      Object[] args = invocation.getArguments();
-      String projectId = (String) args[0];
+  private static ComputeClient setUpClient(List<String> initial, IOException ioException)
+      throws IOException {
+    Compute compute = Mockito.mock(Compute.class);
+    Zones zones = Mockito.mock(Zones.class);
+    Mockito.when(compute.zones()).thenReturn(zones);
+    Zones.List zonesListCall = Mockito.mock(Zones.List.class);
+    Mockito.when(zones.list(anyString())).thenReturn(zonesListCall);
 
-      Zones.List listCall = Mockito.mock(Zones.List.class);
-      if (projectIdToZones.containsKey(projectId)) {
-        List<Zone> zones = new ArrayList<>(projectIdToZones.get(projectId));
-        Mockito.when(listCall.execute()).thenReturn(new ZoneList().setItems(zones));
-      } else if (ERROR_PROJECT_ID.equals(projectId)) {
-        Mockito.when(listCall.execute()).thenThrow(new IOException());
-      } else {
-        Mockito.when(listCall.execute()).thenReturn(new ZoneList().setItems(null));
-      }
-      return listCall;
-    };
+    if (ioException != null) {
+      Mockito.when(zonesListCall.execute()).thenThrow(ioException);
+    } else if (initial == null) {
+      Mockito.when(zonesListCall.execute()).thenReturn(new ZoneList().setItems(null));
+    } else {
+      Mockito.when(zonesListCall.execute())
+          .thenReturn(new ZoneList().setItems(initZoneList(initial)));
+    }
+    return new ComputeClient(compute);
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
@@ -43,10 +43,16 @@ public class ComputeClientTest {
   private static final List<String> ZONE_NAMES =
       Arrays.asList(TEST_ZONE_B, TEST_ZONE_A, TEST_ZONE_C);
 
-  @Test(expected = NullPointerException.class)
-  public void testGetZonesExceptionWhenProjectIdNull() throws NullPointerException, IOException {
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetZonesExceptionWhenProjectIdNull() throws IOException {
     ComputeClient computeClient = setUpClient(null, null);
     computeClient.getZones(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetZonesExceptionWhenProjectIdEmpty() throws IOException {
+    ComputeClient computeClient = setUpClient(null, null);
+    computeClient.getZones("");
   }
 
   @Test(expected = IOException.class)

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
@@ -21,11 +21,12 @@ import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.Compute.Zones;
 import com.google.api.services.compute.model.Zone;
 import com.google.api.services.compute.model.ZoneList;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,36 +37,43 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ComputeClientTest {
   private static final String TEST_PROJECT_ID = "test-project";
-  private static final String WRONG_PROJECT_ID = "wrong-project";
+  private static final String NULL_PROJECT_ID = "wrong-project";
+  private static final String EMPTY_PROJECT_ID = "empty-project-id";
+  private static final String ERROR_PROJECT_ID = "error-project-id";
   private static final List<String> ZONE_NAMES =
       Arrays.asList("us-west-1b", "us-central-1a", "us-east-1c");
   private static ComputeClient computeClient;
-  private static List<Zone> listOfZones;
 
   @BeforeClass
   public static void init() throws IOException {
-    listOfZones = new ArrayList<>();
-
+    List<Zone> listOfZones = initZoneList(ZONE_NAMES);
     // Mock zones
     Compute compute = Mockito.mock(Compute.class);
+
     Zones zones = Mockito.mock(Zones.class);
     Zones.List zonesListCall = Mockito.mock(Zones.List.class);
     ZoneList zoneList = Mockito.mock(ZoneList.class);
-    Zones.List wrongZonesListCall = Mockito.mock(Zones.List.class);
-    ZoneList wrongZoneList = Mockito.mock(ZoneList.class);
     Mockito.when(compute.zones()).thenReturn(zones);
     Mockito.when(zones.list(TEST_PROJECT_ID)).thenReturn(zonesListCall);
     Mockito.when(zonesListCall.execute()).thenReturn(zoneList);
     Mockito.when(zoneList.getItems()).thenReturn(listOfZones);
-    Mockito.when(zones.list(WRONG_PROJECT_ID)).thenReturn(wrongZonesListCall);
-    Mockito.when(wrongZonesListCall.execute()).thenReturn(wrongZoneList);
-    Mockito.when(wrongZoneList.getItems()).thenReturn(null);
-    computeClient = new ComputeClient(compute);
-  }
 
-  @Before
-  public void before() {
-    listOfZones.clear();
+    Zones.List nullZonesListCall = Mockito.mock(Zones.List.class);
+    ZoneList nullZoneList = Mockito.mock(ZoneList.class);
+    Mockito.when(zones.list(NULL_PROJECT_ID)).thenReturn(nullZonesListCall);
+    Mockito.when(nullZonesListCall.execute()).thenReturn(nullZoneList);
+    Mockito.when(nullZoneList.getItems()).thenReturn(null);
+
+    Zones.List emptyZonesListCall = Mockito.mock(Zones.List.class);
+    ZoneList emptyZoneList = Mockito.mock(ZoneList.class);
+    Mockito.when(zones.list(EMPTY_PROJECT_ID)).thenReturn(emptyZonesListCall);
+    Mockito.when(emptyZonesListCall.execute()).thenReturn(emptyZoneList);
+    Mockito.when(emptyZoneList.getItems()).thenReturn(ImmutableList.of());
+
+    Zones.List errorZonesListCall = Mockito.mock(Zones.List.class);
+    Mockito.when(zones.list(ERROR_PROJECT_ID)).thenReturn(errorZonesListCall);
+    Mockito.when(errorZonesListCall.execute()).thenThrow(new IOException());
+    computeClient = new ComputeClient(compute);
   }
 
   @Test(expected = NullPointerException.class)
@@ -73,40 +81,37 @@ public class ComputeClientTest {
     computeClient.getZones(null);
   }
 
-  @Test
-  public void testGetZonesReturnsEmptyWhenEmpty() throws IOException {
-    testGetZones(TEST_PROJECT_ID, new ArrayList<>());
+  @Test(expected = IOException.class)
+  public void testGetZonesExceptionWhenIOException() throws IOException {
+    computeClient.getZones(ERROR_PROJECT_ID);
   }
 
   @Test
-  public void testGetZonesReturnsEmptyWhenProjectIdWrong() throws IOException {
-    testGetZones(WRONG_PROJECT_ID, new ArrayList<>());
+  public void testGetZonesReturnsEmptyWhenZoneListEmpty() throws IOException {
+    List<Zone> zones = computeClient.getZones(EMPTY_PROJECT_ID);
+    assertNotNull(zones);
+    assertEquals(ImmutableList.of(), zones);
+  }
+
+  @Test
+  public void testGetZonesReturnsEmptyWhenZoneListNull() throws IOException {
+    List<Zone> zones = computeClient.getZones(NULL_PROJECT_ID);
+    assertNotNull(zones);
+    assertEquals(ImmutableList.of(), zones);
   }
 
   @Test
   public void testGetZonesReturnsAllSortedWhenProjectIdCorrect() throws IOException {
-    ZONE_NAMES.forEach(name -> listOfZones.add(new Zone().setName(name)));
-    testGetZones(TEST_PROJECT_ID, ZONE_NAMES);
+    List<Zone> expectedZones = initZoneList(ZONE_NAMES);
+    expectedZones.sort(Comparator.comparing(Zone::getName));
+    List<Zone> zones = computeClient.getZones(TEST_PROJECT_ID);
+    assertNotNull(zones);
+    assertEquals(expectedZones, zones);
   }
 
-  private void testGetZones(String projectId, List<String> zoneNames) throws IOException {
-    List<Zone> zones = computeClient.getZones(projectId);
-    assertNotNull("zones was null.", zones);
-    assertEquals(
-        String.format("Expected %d zones but %d zones retrieved.", zones.size(), zoneNames.size()),
-        zoneNames.size(),
-        zones.size());
-
-    if (zoneNames.size() > 0) {
-      zoneNames.sort(String::compareTo);
-      for (int i = 0; i < zoneNames.size(); i++) {
-        assertEquals(
-            String.format(
-                "Zones not sorted. Expected %s but was %s.",
-                zoneNames.get(i), zones.get(i).getName()),
-            zoneNames.get(i),
-            zones.get(i).getName());
-      }
-    }
+  private static List<Zone> initZoneList(List<String> names) {
+    List<Zone> result = new ArrayList<>();
+    names.forEach(z -> result.add(new Zone().setName(z)));
+    return result;
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -39,6 +39,24 @@ public class ContainerClientTest {
   private static final String TEST_CLUSTER = "testCluster";
   private static final String OTHER_CLUSTER = "otherCluster";
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullProjectId() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(null, TEST_ZONE, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullZone() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, null, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithNullClusterName() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, null);
+  }
+
   @Test
   public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
     ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -23,37 +23,100 @@ import com.google.api.services.container.Container.Projects.Zones.Clusters;
 import com.google.api.services.container.model.Cluster;
 import com.google.api.services.container.model.ListClustersResponse;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 /** Tests {@link ContainerClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerClientTest {
   private static final String TEST_PROJECT_ID = "test-project-id";
-  private static final String OTHER_PROJECT_ID = "other-project-id";
-  private static final String ERROR_PROJECT_ID = "error-project-id";
-  private static final String EMPTY_PROJECT_ID = "empty-project-id";
   private static final String TEST_ZONE = "us-west1-a";
-  private static final String OTHER_ZONE = "us-west2-b";
   private static final String TEST_CLUSTER = "testCluster";
   private static final String OTHER_CLUSTER = "otherCluster";
 
-  private static ContainerClient containerClient;
-  private static Cluster testCluster;
+  @Test
+  public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
+    ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);
+    Cluster expected = new Cluster().setName(TEST_CLUSTER);
+    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, TEST_CLUSTER);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
 
-  @BeforeClass
-  public static void init() throws Exception {
+  @Test(expected = IOException.class)
+  public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, new IOException());
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithNullProjectId() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listClusters(null, TEST_ZONE);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithNullZone() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listClusters(TEST_PROJECT_ID, null);
+  }
+
+  @Test
+  public void testListClustersWithValidInputsWhenClustersExist() throws IOException {
+    ContainerClient containerClient = setUpListClient(ImmutableList.of(TEST_CLUSTER), null);
+    List<Cluster> expected = initClusterList(ImmutableList.of(TEST_CLUSTER));
+    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListClustersSortedWithMultipleClusters() throws IOException {
+    ContainerClient containerClient =
+        setUpListClient(ImmutableList.of(TEST_CLUSTER, OTHER_CLUSTER), null);
+    List<Cluster> expected = initClusterList(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER));
+    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListClustersWithValidInputsWhenClustersIsNull() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    List<Cluster> expected = ImmutableList.of();
+    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test
+  public void testListClustersEmptyWithValidProjectWithNoClusters() throws IOException {
+    ContainerClient containerClient = setUpListClient(ImmutableList.of(), null);
+    List<Cluster> expected = ImmutableList.of();
+    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
+    assertNotNull(response);
+    assertEquals(expected, response);
+  }
+
+  @Test(expected = IOException.class)
+  public void testListClustersThrowsErrorWithInvalidProject() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, new IOException());
+    containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
+  }
+
+  private static List<Cluster> initClusterList(List<String> clusterNames) {
+    List<Cluster> clusters = new ArrayList<>();
+    clusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setZone(TEST_ZONE)));
+    return clusters;
+  }
+
+  private static ContainerClient setUpClient(Clusters.List listCall, Clusters.Get getCall)
+      throws IOException {
     Container container = Mockito.mock(Container.class);
     Container.Projects projects = Mockito.mock(Container.Projects.class);
     Container.Projects.Zones zones = Mockito.mock(Container.Projects.Zones.class);
@@ -61,151 +124,41 @@ public class ContainerClientTest {
     Mockito.when(container.projects()).thenReturn(projects);
     Mockito.when(projects.zones()).thenReturn(zones);
     Mockito.when(zones.clusters()).thenReturn(clusters);
-    testCluster = new Cluster().setName(TEST_CLUSTER).setZone(TEST_ZONE);
-    Cluster otherCluster = new Cluster().setName(OTHER_CLUSTER).setZone(TEST_ZONE);
-
-    Mockito.when(clusters.get(anyString(), anyString(), anyString()))
-        .thenAnswer(
-            mockClustersGetAnswer(
-                new ImmutableMap.Builder<String, List<Cluster>>()
-                    .put(TEST_PROJECT_ID, ImmutableList.of(testCluster))
-                    .build()));
-
-    Mockito.when(clusters.list(anyString(), anyString()))
-        .thenAnswer(
-            mockClustersListAnswer(
-                new ImmutableMap.Builder<Pair<String, String>, List<Cluster>>()
-                    .put(
-                        ImmutablePair.of(TEST_PROJECT_ID, TEST_ZONE), ImmutableList.of(testCluster))
-                    .put(
-                        ImmutablePair.of(OTHER_PROJECT_ID, TEST_ZONE),
-                        ImmutableList.of(otherCluster))
-                    .put(ImmutablePair.of(TEST_PROJECT_ID, OTHER_ZONE), ImmutableList.of())
-                    .build()));
-    containerClient = new ContainerClient(container);
+    if (getCall != null) {
+      Mockito.when(clusters.get(anyString(), anyString(), anyString())).thenReturn(getCall);
+    }
+    if (listCall != null) {
+      Mockito.when(clusters.list(anyString(), anyString())).thenReturn(listCall);
+    }
+    return new ContainerClient(container);
   }
 
-  @Test
-  public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
-    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, TEST_CLUSTER);
-    assertNotNull(response);
-    assertEquals(testCluster, response);
+  private static ContainerClient setUpGetClient(String clusterName, IOException ioException)
+      throws IOException {
+    Clusters.Get getCall = Mockito.mock(Clusters.Get.class);
+    ContainerClient client = setUpClient(null, getCall);
+
+    if (ioException != null) {
+      Mockito.when(getCall.execute()).thenThrow(ioException);
+    } else {
+      Mockito.when(getCall.execute()).thenReturn(new Cluster().setName(clusterName));
+    }
+    return client;
   }
 
-  @Test(expected = IOException.class)
-  public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
-    containerClient.getCluster(TEST_PROJECT_ID, OTHER_ZONE, OTHER_CLUSTER);
-  }
+  private static ContainerClient setUpListClient(List<String> clusters, IOException ioException)
+      throws IOException {
+    Clusters.List listCall = Mockito.mock(Clusters.List.class);
+    ContainerClient client = setUpClient(listCall, null);
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testListClustersErrorWithNullProjectId() throws IOException {
-    containerClient.listClusters(null, TEST_ZONE);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testListClustersErrorWithNullZone() throws IOException {
-    containerClient.listClusters(TEST_PROJECT_ID, null);
-  }
-
-  @Test
-  public void testListClustersWithValidInputsWhenClustersExist() throws IOException {
-    List<Cluster> expected = initExpectedClusterList(ImmutableList.of(TEST_CLUSTER));
-    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, TEST_ZONE);
-    assertNotNull(response);
-    assertEquals(expected, response);
-  }
-
-  @Test
-  public void testListClustersWithDifferentProjectClusters() throws IOException {
-    List<Cluster> expected = initExpectedClusterList(ImmutableList.of(OTHER_CLUSTER));
-    List<Cluster> response = containerClient.listClusters(OTHER_PROJECT_ID, TEST_ZONE);
-    assertNotNull(response);
-    assertEquals(expected, response);
-  }
-
-  @Test
-  public void testListClustersWithValidInputsWhenClustersIsNull() throws IOException {
-    List<Cluster> expected = ImmutableList.of();
-    List<Cluster> response = containerClient.listClusters(EMPTY_PROJECT_ID, TEST_ZONE);
-    assertNotNull(response);
-    assertEquals(expected, response);
-  }
-
-  @Test
-  public void testListClustersEmptyWithValidProjectWithNoClusters() throws IOException {
-    List<Cluster> expected = ImmutableList.of();
-    List<Cluster> response = containerClient.listClusters(TEST_PROJECT_ID, OTHER_ZONE);
-    assertNotNull(response);
-    assertEquals(expected, response);
-  }
-
-  @Test(expected = IOException.class)
-  public void testListClustersThrowsErrorWithInvalidProject() throws IOException {
-    containerClient.listClusters(ERROR_PROJECT_ID, TEST_ZONE);
-  }
-
-  private static List<Cluster> initExpectedClusterList(List<String> expectedClusterNames) {
-    List<Cluster> clusters = new ArrayList<>();
-    expectedClusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setZone(TEST_ZONE)));
-    return clusters;
-  }
-
-  private static Answer<Container.Projects.Zones.Clusters.Get> mockClustersGetAnswer(
-      ImmutableMap<String, List<Cluster>> projectToClusters) {
-    return invocation -> {
-      Object[] args = invocation.getArguments();
-      String projectId = (String) args[0];
-      String zone = (String) args[1];
-      String clusterName = (String) args[2];
-      if (!projectToClusters.containsKey(projectId)) {
-        throw new IOException(
-            String.format(
-                "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
-                projectId, zone, clusterName));
-      }
-
-      Optional<Cluster> cluster =
-          projectToClusters
-              .get(projectId)
-              .stream()
-              .filter(c -> c.getName().equals(clusterName) && c.getZone().equals(zone))
-              .findFirst();
-      if (!cluster.isPresent()) {
-        throw new IOException(
-            String.format(
-                "Failed to find cluster, projectId: %s, zone: %s, cluster: %s",
-                projectId, zone, clusterName));
-      }
-
-      Container.Projects.Zones.Clusters.Get getCall =
-          Mockito.mock(Container.Projects.Zones.Clusters.Get.class);
-      Mockito.when(getCall.execute()).thenReturn(cluster.get());
-      return getCall;
-    };
-  }
-
-  private static Answer<Container.Projects.Zones.Clusters.List> mockClustersListAnswer(
-      ImmutableMap<Pair<String, String>, List<Cluster>> projectToClusters) {
-    return invocation -> {
-      Object[] args = invocation.getArguments();
-      String projectId = (String) args[0];
-      String zone = (String) args[1];
-      Pair<String, String> parent = ImmutablePair.of(projectId, zone);
-
-      List<Cluster> clusters = null;
-      if (projectToClusters.containsKey(parent)) {
-        clusters = new ArrayList<>(projectToClusters.get(parent));
-      } else if (ERROR_PROJECT_ID.equals(projectId)) {
-        throw new IOException(
-            String.format(
-                "Failed to get clusters for projectId: %s and zone: %s", projectId, zone));
-      }
-
-      Container.Projects.Zones.Clusters.List listCall =
-          Mockito.mock(Container.Projects.Zones.Clusters.List.class);
-      ListClustersResponse response = new ListClustersResponse().setClusters(clusters);
-      Mockito.when(listCall.execute()).thenReturn(response);
-      return listCall;
-    };
+    if (ioException != null) {
+      Mockito.when(listCall.execute()).thenThrow(ioException);
+    } else if (clusters == null) {
+      Mockito.when(listCall.execute()).thenReturn(new ListClustersResponse().setClusters(null));
+    } else {
+      Mockito.when(listCall.execute())
+          .thenReturn(new ListClustersResponse().setClusters(initClusterList(clusters)));
+    }
+    return client;
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -57,6 +57,24 @@ public class ContainerClientTest {
     containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, null);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyProjectId() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster("", TEST_ZONE, TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyZone() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, "", TEST_CLUSTER);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetClustersErrorWithEmptyClusterName() throws IOException {
+    ContainerClient containerClient = setUpGetClient(null, null);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, "");
+  }
+
   @Test
   public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
     ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);
@@ -82,6 +100,18 @@ public class ContainerClientTest {
   public void testListClustersErrorWithNullZone() throws IOException {
     ContainerClient containerClient = setUpListClient(null, null);
     containerClient.listClusters(TEST_PROJECT_ID, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithEmptyProjectId() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listClusters("", TEST_ZONE);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testListClustersErrorWithEmptyZone() throws IOException {
+    ContainerClient containerClient = setUpListClient(null, null);
+    containerClient.listClusters(TEST_PROJECT_ID, "");
   }
 
   @Test


### PR DESCRIPTION
As mentioned in #27, this change refactors the unit tests so they can run in parallel. Also did some readability refactoring for the client tests that were not addressed in the most recent test refactoring in #12.

I tested this locally, although I had other maven errors that weren't related to the execution of these unit tests. In their current form, here is the an example of the difference in execution time when run before and after enabling the "parallel" flag:

- KubernetesEngineBuilderTest: **0.901s** -> **0.044s**
- CloudResourceManagerClientTest: **0.235s** -> **0.211s**
- ContainerClientTest: **0.192s** -> **0.101s**
- ComputeClientTest: **0.132s** -> **0.07s**
