### PR TITLE
Add license headers and fix existing license headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 language: java
 sudo: false
 script: mvn clean test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+ 
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # How to contribute
 
 We'd love to accept your patches and contributions to this project. There are

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Google Kubernetes Engine Plugin for Jenkins
 The Google Kubernetes Engine (GKE) Plugin allows you to deploy build artifacts to Kubernetes clusters running in GKE with Jenkins.
 

--- a/checkstyleJavaHeader
+++ b/checkstyleJavaHeader
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright 201(8) Google Inc\. All Rights Reserved\.$
+^ \* Copyright 201(8) Google LLC$
 ^ \*$
 ^ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);$
 ^ \* you may not use this file except in compliance with the License\.$

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Google Kubernetes Engine Plugin Documentation
 
 The [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) (GKE) Plugin allows you to publish deployments built within Jenkins to your Kubernetes clusters running within GKE.

--- a/docs/SourceBuildInstallation.md
+++ b/docs/SourceBuildInstallation.md
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 # Plugin Source Build Installation
 
 1. Clone the plugin and enter the directory:

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/JenkinsRunContext.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/JenkinsRunContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubectlWrapper.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubectlWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ComputeClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerScopeRequirement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/RetryHttpInitializerWrapper.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/RetryHttpInitializerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form" xmlns:c="/lib/credentials">

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-clusterName.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-clusterName.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <div>
   <p>${%text}</p>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-clusterName.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-clusterName.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 text=Select the name of the cluster that you will be deploying to.
 link.url=https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture
 link.text=Cluster Architecture on the GKE documentation.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-credentialsId.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-credentialsId.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <div>
   <p>${%text}</p>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-credentialsId.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-credentialsId.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 text=Select the Google OAuth private key based service account.
 link.url=https://github.com/jenkinsci/google-kubernetes-engine-plugin/blob/develop/docs/Home.md#iam-credentials
 link.text=IAM Credentials on the Google Kubernetes Engine Plugin documentation.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-manifestPattern.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-manifestPattern.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <div>
   <p>${%text}</p>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-manifestPattern.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-manifestPattern.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 text=Enter the name of the file or directory that contain your Kubernetes manifest(s).
 link.url=https://kubernetes.io/docs/concepts/overview/object-management-kubectl/declarative-config/#how-to-create-objects
 link.text=Declarative Config on the Kubernetes documentation.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-projectId.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-projectId.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <div>
   <p>${%text}</p>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-projectId.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-projectId.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 text=Select the identifier for the project where your cluster lives.
 link.url=https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects
 link.text=Identifying Projects on the Cloud Resource Manager documentation.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-zone.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-zone.jelly
@@ -1,3 +1,16 @@
+<!--
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ compliance with the License. You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License
+ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing permissions and limitations under the
+ License.
+-->
 <?jelly escape-by-default='true'?>
 <div>
   <p>${%text}</p>

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-zone.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-zone.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 text=Select the zone where the cluster lives.
 link.url=https://cloud.google.com/compute/docs/regions-zones/#available
 link.text=Available Zones on the GCE documentation.

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/Messages.properties
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 KubernetesEngineBuilder.DisplayName=Deploy to Google Kubernetes Engine
 KubernetesEngineBuilder.ClusterRequired=Cluster is required
 KubernetesEngineBuilder.ClusterFillError=Error retrieving clusters from GKE

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/client/Messages.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/client/Messages.properties
@@ -1,2 +1,13 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 ClientFactory.FailedToRetrieveCredentials=Could not retrieve credentials: {0}
 ClientFactory.FailedToInitializeHTTPTransport=Failed to initialize HTTP transport: {0}

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,8 +1,11 @@
 <!--
- Copyright 2019 Google Inc.
+ Copyright 2019 Google LLC
+
  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
  compliance with the License. You may obtain a copy of the License at
+
         https://www.apache.org/licenses/LICENSE-2.0
+
  Unless required by applicable law or agreed to in writing, software distributed under the License
  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
  implied. See the License for the specific language governing permissions and limitations under the

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/StringJsonServiceAccountConfig.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/StringJsonServiceAccountConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/CloudResourceManagerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc. All Rights Reserved.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ComputeClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google Inc.
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/resources/expectedKubeConfig.yml
+++ b/src/test/resources/expectedKubeConfig.yml
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 apiVersion: v1
 clusters:
 - cluster:

--- a/src/test/resources/testDeployment.yml
+++ b/src/test/resources/testDeployment.yml
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/test/resources/testMalformedDeployment.yml
+++ b/src/test/resources/testMalformedDeployment.yml
@@ -1,3 +1,14 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing permissions and limitations under the
+# License.
 apiVersion: apps/v1
  laksjdflkj dkljf;fds;::
  :


### PR DESCRIPTION
Apart from adding the header to the files that were missing it, I'm changing the existing headers to match the apache header listed in the open source releasing guide, available externally [here](https://opensource.google.com/docs/releasing/preparing/#Apache-header)

