### PR TITLE
Issue #56: Include compile explicitly in build from source command.

### DIFF
--- a/docs/SourceBuildInstallation.md
+++ b/docs/SourceBuildInstallation.md
@@ -25,7 +25,7 @@
     ```
 1. Build the plugin into a .hpi plugin file:
     ```bash
-    mvn hpi:hpi
+    mvn compile hpi:hpi
     ```
 1. Go to **Manage Jenkins** then **Manage Plugins**.
 1. In the Plugin Manager, click the **Advanced** tab and then **Choose File** under the **Upload Plugin** section.


### PR DESCRIPTION
I discovered with a fresh clone that `mvn hpi:hpi` does not perform the compile step. Previous successes at running this command have been because usually we run `mvn test`, `mvn verify`, or `mvn hpi:run` beforehand which do perform compilation.