### PR TITLE
Issue #67: Make command launcher logs quiet

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubectlWrapper.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubectlWrapper.java
@@ -141,7 +141,8 @@ public class KubectlWrapper {
   private static String launchAndJoinCommand(Launcher launcher, List<String> args)
       throws IOException, InterruptedException {
     ByteArrayOutputStream cmdLogStream = new ByteArrayOutputStream();
-    int status = launcher.launch().cmds(args).stderr(cmdLogStream).stdout(cmdLogStream).join();
+    int status =
+        launcher.launch().cmds(args).stderr(cmdLogStream).stdout(cmdLogStream).quiet(true).join();
     if (status != 0) {
       String logs = cmdLogStream.toString(CHARSET);
       LOGGER.log(Level.SEVERE, String.format("kubectl command log: %s", logs));

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -88,6 +88,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
   private int verifyTimeoutInMinutes = DEFAULT_VERIFY_TIMEOUT_MINUTES;
   private boolean verifyServices;
   private boolean isTestCleanup;
+  private boolean verboseLogging = false;
   private LinkedList<KubeConfigAfterBuildStep> afterBuildStepStack;
 
   /** Constructs a new {@link KubernetesEngineBuilder}. */
@@ -180,6 +181,15 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
     this.verifyTimeoutInMinutes = verifyTimeoutInMinutes;
   }
 
+  public boolean isVerboseLogging() {
+    return this.verboseLogging;
+  }
+
+  @DataBoundSetter
+  public void setVerboseLogging(boolean verboseLogging) {
+    this.verboseLogging = verboseLogging;
+  }
+
   @VisibleForTesting
   void pushAfterBuildStep(KubeConfigAfterBuildStep afterBuildStep) {
     if (afterBuildStepStack == null) {
@@ -214,6 +224,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
             .launcher(launcher)
             .kubeConfig(kubeConfig)
             .namespace(namespace)
+            .verboseLogging(verboseLogging)
             .build();
 
     FilePath manifestFile = workspace.child(manifestPattern);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
@@ -11,16 +11,16 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
+/** Tests for verifying the use of the verboseLogging flag in {@link KubectlWrapper}.*/
 @RunWith(MockitoJUnitRunner.class)
 public class KubectlWrapperVerboseLoggingTest {
-
   @Test(expected = IOException.class)
-  public void testQuietLoggingAppliedInPerform() throws IOException, InterruptedException {
+  public void testQuietLoggingApplied() throws IOException, InterruptedException {
     KubectlWrapper kubectlWrapper =
         Mockito.spy(
             new KubectlWrapper.Builder()
-                .kubeConfig(setUpKubeconfig())
                 .launcher(setUpLauncher())
+                .kubeConfig(setUpKubeconfig())
                 .workspace(setUpWorkspace())
                 .namespace("")
                 .verboseLogging(false)
@@ -29,12 +29,12 @@ public class KubectlWrapperVerboseLoggingTest {
   }
 
   @Test
-  public void testVerboseLoggingAppliedInPerform() throws IOException, InterruptedException {
+  public void testVerboseLoggingApplied() throws IOException, InterruptedException {
     KubectlWrapper kubectlWrapper =
         Mockito.spy(
             new KubectlWrapper.Builder()
-                .kubeConfig(setUpKubeconfig())
                 .launcher(setUpLauncher())
+                .kubeConfig(setUpKubeconfig())
                 .workspace(setUpWorkspace())
                 .namespace("")
                 .verboseLogging(true)
@@ -57,6 +57,13 @@ public class KubectlWrapperVerboseLoggingTest {
     return launcher;
   }
 
+  private KubeConfig setUpKubeconfig() throws IOException {
+    KubeConfig kubeConfig = Mockito.mock(KubeConfig.class);
+    Mockito.when(kubeConfig.toYaml()).thenReturn("yaml");
+    Mockito.when(kubeConfig.getCurrentContext()).thenReturn("currentContext");
+    return kubeConfig;
+  }
+
   private FilePath setUpWorkspace() throws IOException, InterruptedException {
     FilePath kubeConfigFile = Mockito.mock(FilePath.class);
     Mockito.when(kubeConfigFile.getRemote()).thenReturn("remote");
@@ -65,12 +72,5 @@ public class KubectlWrapperVerboseLoggingTest {
     Mockito.when(workspace.createTempFile(".kube","config")).thenReturn(kubeConfigFile);
     Mockito.when(workspace.child("remote")).thenReturn(kubeConfigFile);
     return workspace;
-  }
-
-  private KubeConfig setUpKubeconfig() throws IOException {
-    KubeConfig kubeConfig = Mockito.mock(KubeConfig.class);
-    Mockito.when(kubeConfig.toYaml()).thenReturn("yaml");
-    Mockito.when(kubeConfig.getCurrentContext()).thenReturn("currentContext");
-    return kubeConfig;
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
@@ -1,0 +1,76 @@
+package com.google.jenkins.plugins.k8sengine;
+
+import com.google.common.collect.ImmutableList;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Launcher.ProcStarter;
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KubectlWrapperVerboseLoggingTest {
+
+  @Test(expected = IOException.class)
+  public void testQuietLoggingAppliedInPerform() throws IOException, InterruptedException {
+    KubectlWrapper kubectlWrapper =
+        Mockito.spy(
+            new KubectlWrapper.Builder()
+                .kubeConfig(setUpKubeconfig())
+                .launcher(setUpLauncher())
+                .workspace(setUpWorkspace())
+                .namespace("")
+                .verboseLogging(false)
+                .build());
+    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of( "-f", "manifest.yaml"));
+  }
+
+  @Test
+  public void testVerboseLoggingAppliedInPerform() throws IOException, InterruptedException {
+    KubectlWrapper kubectlWrapper =
+        Mockito.spy(
+            new KubectlWrapper.Builder()
+                .kubeConfig(setUpKubeconfig())
+                .launcher(setUpLauncher())
+                .workspace(setUpWorkspace())
+                .namespace("")
+                .verboseLogging(true)
+                .build());
+    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of( "-f", "manifest.yaml"));
+  }
+
+  private Launcher setUpLauncher() throws IOException, InterruptedException {
+    ProcStarter procStarter = Mockito.mock(ProcStarter.class);
+    Mockito.when(procStarter.cmds(Mockito.anyList())).thenReturn(procStarter);
+    Mockito.when(procStarter.stdout(Mockito.any(OutputStream.class))).thenReturn(procStarter);
+    Mockito.when(procStarter.stderr(Mockito.any(OutputStream.class))).thenReturn(procStarter);
+    Mockito.when(procStarter.join()).thenReturn(0);
+    ProcStarter quietProcStarter = Mockito.mock(ProcStarter.class);
+    Mockito.when(quietProcStarter.join()).thenReturn(1);
+    Mockito.when(procStarter.quiet(true)).thenReturn(quietProcStarter);
+    Mockito.when(procStarter.quiet(false)).thenReturn(procStarter);
+    Launcher launcher = Mockito.mock(Launcher.class);
+    Mockito.when(launcher.launch()).thenReturn(procStarter);
+    return launcher;
+  }
+
+  private FilePath setUpWorkspace() throws IOException, InterruptedException {
+    FilePath kubeConfigFile = Mockito.mock(FilePath.class);
+    Mockito.when(kubeConfigFile.getRemote()).thenReturn("remote");
+    Mockito.when(kubeConfigFile.delete()).thenReturn(true);
+    FilePath workspace = Mockito.mock(FilePath.class);
+    Mockito.when(workspace.createTempFile(".kube","config")).thenReturn(kubeConfigFile);
+    Mockito.when(workspace.child("remote")).thenReturn(kubeConfigFile);
+    return workspace;
+  }
+
+  private KubeConfig setUpKubeconfig() throws IOException {
+    KubeConfig kubeConfig = Mockito.mock(KubeConfig.class);
+    Mockito.when(kubeConfig.toYaml()).thenReturn("yaml");
+    Mockito.when(kubeConfig.getCurrentContext()).thenReturn("currentContext");
+    return kubeConfig;
+  }
+}

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.jenkins.plugins.k8sengine;
 
 import com.google.common.collect.ImmutableList;

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubectlWrapperVerboseLoggingTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for verifying the use of the verboseLogging flag in {@link KubectlWrapper}.*/
+/** Tests for verifying the use of the verboseLogging flag in {@link KubectlWrapper}. */
 @RunWith(MockitoJUnitRunner.class)
 public class KubectlWrapperVerboseLoggingTest {
   @Test(expected = IOException.class)
@@ -25,7 +25,7 @@ public class KubectlWrapperVerboseLoggingTest {
                 .namespace("")
                 .verboseLogging(false)
                 .build());
-    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of( "-f", "manifest.yaml"));
+    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of("-f", "manifest.yaml"));
   }
 
   @Test
@@ -39,7 +39,7 @@ public class KubectlWrapperVerboseLoggingTest {
                 .namespace("")
                 .verboseLogging(true)
                 .build());
-    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of( "-f", "manifest.yaml"));
+    kubectlWrapper.runKubectlCommand("apply", ImmutableList.of("-f", "manifest.yaml"));
   }
 
   private Launcher setUpLauncher() throws IOException, InterruptedException {
@@ -69,7 +69,7 @@ public class KubectlWrapperVerboseLoggingTest {
     Mockito.when(kubeConfigFile.getRemote()).thenReturn("remote");
     Mockito.when(kubeConfigFile.delete()).thenReturn(true);
     FilePath workspace = Mockito.mock(FilePath.class);
-    Mockito.when(workspace.createTempFile(".kube","config")).thenReturn(kubeConfigFile);
+    Mockito.when(workspace.createTempFile(".kube", "config")).thenReturn(kubeConfigFile);
     Mockito.when(workspace.child("remote")).thenReturn(kubeConfigFile);
     return workspace;
   }


### PR DESCRIPTION
See #67: The command launcher logs are used to retrieve the json manifests of the deployments through kubectl, but in some configurations this means that the user sees that full command output such as a giant deployment manifest. Adding the quiet=true flag makes it so that we can still use the output without so much clutter for the end user. If the command fails, the error messages/command output will still be logged.