### PR TITLE
Refactor zone -> location so that regional clusters are also supported

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -79,12 +79,12 @@ the file was created, you will upload it to Jenkins in a subsequent step:
 1. Create a GKE cluster*:
     ```bash
     export CLUSTER=my-jenkins-cluster
-    export ZONE=us-central1-c
-    gcloud container clusters create --zone $ZONE $CLUSTER
+    export LOCATION=us-central1-c
+    gcloud container clusters create --zone $LOCATION $CLUSTER
     ```
 1. Get credentials for the cluster:
     ```bash
-    gcloud container clusters get-credentials --zone $ZONE $CLUSTER
+    gcloud container clusters get-credentials --zone $LOCATION $CLUSTER
     ```
 
 ### Configure Kubernetes Cluster Permissions
@@ -135,7 +135,8 @@ The GKE Build Step has the following parameters:
 
 1. credentialsId(string): The ID of the credentials that you uploaded earlier.
 1. projectId(string): The Project ID housing the GKE cluster to be published to.
-1. zone(string): The Zone housing the GKE cluster to be published to.
+1. zone(string): [**Deprecated**] The Zone housing the GKE cluster to be published to.
+1. location(string): The Zone or Region housing the GKE cluster to be published to.
 1. clusterName(string): The name of the Cluster to be published to.
 1. manifestPattern(string): The file pattern of the Kubernetes manifest to be deployed.
 1. verifyDeployments(boolean): [Optional] Whether the plugin will verify deployments.
@@ -148,7 +149,6 @@ The GKE Build Step has the following parameters:
 click Google Kubernetes Engine.
 1. In the Service Account Credentials dropdown, select the credentials that you uploaded earlier.
 1. Select the Project ID housing the GKE cluster to be published to.
-1. Select the Zone housing the GKE cluster to be published to.
 1. Select the Cluster to be published to.
 1. Enter the file path of the Kubernetes [manifest](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) within your project to be used for deployment.
 
@@ -164,13 +164,13 @@ pipeline {
     environment {
         PROJECT_ID = '<YOUR_PROJECT_ID>'
         CLUSTER_NAME = '<YOUR_CLUSTER_NAME>'
-        ZONE = '<YOUR_CLUSTER_ZONE>'
+        LOCATION = '<YOUR_CLUSTER_LOCATION>'
         CREDENTIALS_ID = '<YOUR_CREDENTIAS_ID>'
     }
     stages {
         stage('Deploy to GKE') {
             steps{
-                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, zone: env.ZONE, manifestPattern: 'manifest.yaml', credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
+                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, location: env.LOCATION, manifestPattern: 'manifest.yaml', credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
             }
         }
     }

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -79,12 +79,12 @@ the file was created, you will upload it to Jenkins in a subsequent step:
 1. Create a GKE cluster*:
     ```bash
     export CLUSTER=my-jenkins-cluster
-    export LOCATION=us-central1-c
-    gcloud container clusters create --zone $LOCATION $CLUSTER
+    export ZONE=us-central1-c
+    gcloud container clusters create --zone $ZONE $CLUSTER
     ```
 1. Get credentials for the cluster:
     ```bash
-    gcloud container clusters get-credentials --zone $LOCATION $CLUSTER
+    gcloud container clusters get-credentials --zone $ZONE $CLUSTER
     ```
 
 ### Configure Kubernetes Cluster Permissions

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/ClusterUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/ClusterUtil.java
@@ -24,54 +24,54 @@ import com.google.common.base.Strings;
 /** Utility functions for converting between {@link Cluster}s and their String representations. */
 class ClusterUtil {
   /**
-   * Given a GKE {@link Cluster} return a String representation containing the name and zone.
+   * Given a GKE {@link Cluster} return a String representation containing the name and location.
    *
    * @param cluster The {@link Cluster} object to extract values from.
-   * @return A String of the form "name (zone)" based on the given cluster's properties.
+   * @return A String of the form "name (location)" based on the given cluster's properties.
    */
-  static String toNameAndZone(Cluster cluster) {
+  static String toNameAndLocation(Cluster cluster) {
     Preconditions.checkNotNull(cluster);
-    return toNameAndZone(cluster.getName(), cluster.getZone());
+    return toNameAndLocation(cluster.getName(), cluster.getLocation());
   }
 
   /**
-   * Given a name and zone for a cluster, return the combined String representation.
+   * Given a name and location for a cluster, return the combined String representation.
    *
    * @param name A non-empty cluster name
-   * @param zone A non-empty GCP resource zone.
-   * @return A String of the form "name (zone)".
+   * @param location A non-empty GCP resource location.
+   * @return A String of the form "name (location)".
    */
-  static String toNameAndZone(String name, String zone) {
+  static String toNameAndLocation(String name, String location) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(zone));
-    return String.format("%s (%s)", name, zone);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
+    return String.format("%s (%s)", name, location);
   }
 
   /**
    * Only used for mocking the {@link com.google.jenkins.plugins.k8sengine.client.ContainerClient}.
-   * Constructs a {@link Cluster} from the given nameAndZone value.
+   * Constructs a {@link Cluster} from the given nameAndLocation value.
    *
-   * @param nameAndZone A non-empty String of the form "name (zone)"
-   * @return A cluster with the name and zone properties from the provided nameAndZone.
+   * @param nameAndLocation A non-empty String of the form "name (location)"
+   * @return A cluster with the name and location properties from the provided nameAndLocation.
    */
   @VisibleForTesting
-  static Cluster fromNameAndZone(String nameAndZone) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndZone));
-    String[] values = valuesFromNameAndZone(nameAndZone);
-    return new Cluster().setName(values[0]).setZone(values[1]);
+  static Cluster fromNameAndLocation(String nameAndLocation) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
+    String[] values = valuesFromNameAndLocation(nameAndLocation);
+    return new Cluster().setName(values[0]).setLocation(values[1]);
   }
 
   /**
-   * Extracts the individual values from a combined nameAndZone String.
+   * Extracts the individual values from a combined nameAndLocation String.
    *
-   * @param nameAndZone A non-empty String of the form "name (zone)"
-   * @return The String array {name, zone} from the provided value.
+   * @param nameAndLocation A non-empty String of the form "name (location)"
+   * @return The String array {name, location} from the provided value.
    */
-  static String[] valuesFromNameAndZone(String nameAndZone) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndZone));
-    String[] clusters = nameAndZone.split(" [(]");
+  static String[] valuesFromNameAndLocation(String nameAndLocation) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
+    String[] clusters = nameAndLocation.split(" [(]");
     if (clusters.length != 2) {
-      throw new IllegalArgumentException("nameAndZone should be of the form 'name (zone)'");
+      throw new IllegalArgumentException("nameAndLocation should be of the form 'name (location)'");
     }
     clusters[1] = clusters[1].substring(0, clusters[1].length() - 1);
     return clusters;

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
@@ -147,7 +147,8 @@ public class KubeConfig {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkNotNull(cluster);
 
-    final String currentContext = contextString(projectId, cluster.getZone(), cluster.getName());
+    final String currentContext =
+        contextString(projectId, cluster.getLocation(), cluster.getName());
     return new KubeConfig.Builder()
         .currentContext(currentContext)
         .contexts(ImmutableList.<Object>of(context(currentContext)))
@@ -157,11 +158,11 @@ public class KubeConfig {
   }
 
   @VisibleForTesting
-  static String contextString(String project, String zone, String cluster) {
+  static String contextString(String project, String location, String cluster) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(project));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(zone));
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    return String.format(KUBECONTEXT_FORMAT, project, zone, cluster);
+    return String.format(KUBECONTEXT_FORMAT, project, location, cluster);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
@@ -30,7 +30,7 @@ import java.util.List;
  *     Engine</a>
  */
 public class ContainerClient {
-  private static final String ZONE_WILDCARD = "-";
+  private static final String LOCATION_WILDCARD = "-";
   private final Container container;
 
   /**
@@ -47,16 +47,16 @@ public class ContainerClient {
    * Retrieves a {@link Cluster} from the container client.
    *
    * @param projectId The ID of the project the cluster resides in.
-   * @param zone The location of the cluster.
+   * @param location The location of the cluster.
    * @param cluster The name of the cluster.
    * @return The retrieved {@link Cluster}.
    * @throws IOException When an error occurred attempting to get the cluster.
    */
-  public Cluster getCluster(String projectId, String zone, String cluster) throws IOException {
+  public Cluster getCluster(String projectId, String location, String cluster) throws IOException {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(zone));
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    return container.projects().zones().clusters().get(projectId, zone, cluster).execute();
+    return container.projects().zones().clusters().get(projectId, location, cluster).execute();
   }
 
   /**
@@ -73,7 +73,7 @@ public class ContainerClient {
             .projects()
             .zones()
             .clusters()
-            .list(projectId, ZONE_WILDCARD)
+            .list(projectId, LOCATION_WILDCARD)
             .execute()
             .getClusters();
     if (clusters == null) {

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerClient.java
@@ -56,7 +56,12 @@ public class ContainerClient {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    return container.projects().zones().clusters().get(projectId, location, cluster).execute();
+    return container
+        .projects()
+        .locations()
+        .clusters()
+        .get(toApiName(projectId, location, cluster))
+        .execute();
   }
 
   /**
@@ -71,9 +76,9 @@ public class ContainerClient {
     List<Cluster> clusters =
         container
             .projects()
-            .zones()
+            .locations()
             .clusters()
-            .list(projectId, LOCATION_WILDCARD)
+            .list(toApiParent(projectId))
             .execute()
             .getClusters();
     if (clusters == null) {
@@ -81,5 +86,13 @@ public class ContainerClient {
     }
     clusters.sort(Comparator.comparing(Cluster::getName));
     return ImmutableList.copyOf(clusters);
+  }
+
+  private static String toApiName(String projectId, String location, String clusterName) {
+    return String.format("projects/%s/locations/%s/clusters/%s", projectId, location, clusterName);
+  }
+
+  private static String toApiParent(String projectId) {
+    return String.format("projects/%s/locations/%s", projectId, LOCATION_WILDCARD);
   }
 }

--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-cluster.properties
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/help-cluster.properties
@@ -9,6 +9,8 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied. See the License for the specific language governing permissions and limitations under the
 # License.
-text=Select the name of the cluster that you will be deploying to.
+text=Select the cluster that you will be deploying to. The values have the form "name \
+  (location)" where name is the cluster's name and location is the compute Zone or Region where \
+  the cluster exists.
 link.url=https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture
 link.text=Cluster Architecture on the GKE documentation.

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/ClusterUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/ClusterUtilTest.java
@@ -23,53 +23,53 @@ import org.junit.Test;
 /** Tests for verifying the behavior of {@link ClusterUtil methods} */
 public class ClusterUtilTest {
   @Test(expected = NullPointerException.class)
-  public void testToNameAndZoneNullCluster() {
-    ClusterUtil.toNameAndZone(null);
+  public void testToNameAndLocationNullCluster() {
+    ClusterUtil.toNameAndLocation(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndZoneNullName() {
-    ClusterUtil.toNameAndZone(null, "us-west1-a");
+  public void testToNameAndLocationNullName() {
+    ClusterUtil.toNameAndLocation(null, "us-west1-a");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndZoneEmptyName() {
-    ClusterUtil.toNameAndZone("", "us-west1-a");
+  public void testToNameAndLocationEmptyName() {
+    ClusterUtil.toNameAndLocation("", "us-west1-a");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndZoneNullZone() {
-    ClusterUtil.toNameAndZone("test-cluster", null);
+  public void testToNameAndLocationNullLocation() {
+    ClusterUtil.toNameAndLocation("test-cluster", null);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndZoneEmptyZone() {
-    ClusterUtil.toNameAndZone("test-cluster", "");
+  public void testToNameAndLocationEmptyLocation() {
+    ClusterUtil.toNameAndLocation("test-cluster", "");
   }
 
   @Test
-  public void testToNameAndZoneValidInputs() {
+  public void testToNameAndLocationValidInputs() {
     assertEquals(
-        "test-cluster (us-west1-a)", ClusterUtil.toNameAndZone("test-cluster", "us-west1-a"));
+        "test-cluster (us-west1-a)", ClusterUtil.toNameAndLocation("test-cluster", "us-west1-a"));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndZoneNullInput() {
-    ClusterUtil.valuesFromNameAndZone(null);
+  public void testValuesFromNameAndLocationNullInput() {
+    ClusterUtil.valuesFromNameAndLocation(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndZoneEmptyInput() {
-    ClusterUtil.valuesFromNameAndZone("");
+  public void testValuesFromNameAndLocationEmptyInput() {
+    ClusterUtil.valuesFromNameAndLocation("");
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndZoneMalformedInput() {
-    ClusterUtil.valuesFromNameAndZone("test us-west1-a");
+  public void testValuesFromNameAndLocationMalformedInput() {
+    ClusterUtil.valuesFromNameAndLocation("test us-west1-a");
   }
 
   @Test
-  public void testValuesFromNameAndZoneValidInput() {
-    ClusterUtil.valuesFromNameAndZone("test-cluster (us-west1-a)");
+  public void testValuesFromNameAndLocationValidInput() {
+    ClusterUtil.valuesFromNameAndLocation("test-cluster (us-west1-a)");
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/ITUtil.java
@@ -16,6 +16,8 @@
 
 package com.google.jenkins.plugins.k8sengine;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.google.common.io.ByteStreams;
 import hudson.FilePath;
 import hudson.model.Project;
@@ -97,5 +99,19 @@ public class ITUtil {
     while ((line = reader.readLine()) != null) {
       logger.info(line);
     }
+  }
+
+  /**
+   * Retrieves the location set through environment variables
+   *
+   * @return A Google Compute Resource Region (us-west1) or Zone (us-west1-a) string
+   */
+  static String getLocation() {
+    String location = System.getenv("GOOGLE_PROJECT_LOCATION");
+    if (location == null) {
+      location = System.getenv("GOOGLE_PROJECT_ZONE");
+    }
+    assertNotNull("GOOGLE_PROJECT_LOCATION env var must be set", location);
+    return location;
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
@@ -62,7 +62,7 @@ public class KubeConfigTest {
   public void testFromClusterReturnsProperly() throws Exception {
     Cluster cluster = Mockito.mock(Cluster.class);
     Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
-    Mockito.when(cluster.getZone()).thenReturn("us-central1-c");
+    Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
     Mockito.when(cluster.getName()).thenReturn("testCluster");
     MasterAuth auth = Mockito.mock(MasterAuth.class);
     Mockito.when(cluster.getMasterAuth()).thenReturn(auth);
@@ -88,7 +88,7 @@ public class KubeConfigTest {
   public void testToYamlReturnsProperly() throws Exception {
     Cluster cluster = Mockito.mock(Cluster.class);
     Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
-    Mockito.when(cluster.getZone()).thenReturn("us-central1-c");
+    Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
     Mockito.when(cluster.getName()).thenReturn("testCluster");
     MasterAuth auth = Mockito.mock(MasterAuth.class);
     Mockito.when(cluster.getMasterAuth()).thenReturn(auth);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
@@ -284,7 +284,7 @@ public class KubernetesEngineBuilderClusterTest {
 
     List<Cluster> clusters = new ArrayList<>();
 
-    initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndZone(c)));
+    initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
     Mockito.when(containerClient.listAllClusters(anyString()))
         .thenReturn(ImmutableList.copyOf(clusters));
     return descriptor;

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
@@ -20,6 +20,7 @@ import static com.google.jenkins.plugins.k8sengine.ITUtil.copyTestFileToDir;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.createTestWorkspace;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.formatRandomName;
+import static com.google.jenkins.plugins.k8sengine.ITUtil.getLocation;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -62,7 +63,7 @@ public class KubernetesEngineBuilderIT {
 
   private static String clusterName;
   private static String projectId;
-  private static String testZone;
+  private static String testLocation;
   private static String credentialsId;
   private static ContainerClient client;
 
@@ -73,8 +74,7 @@ public class KubernetesEngineBuilderIT {
     projectId = System.getenv("GOOGLE_PROJECT_ID");
     assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
 
-    testZone = System.getenv("GOOGLE_PROJECT_ZONE");
-    assertNotNull("GOOGLE_PROJECT_ZONE env var must be set", testZone);
+    testLocation = getLocation();
 
     clusterName = System.getenv("GOOGLE_GKE_CLUSTER");
     assertNotNull("GOOGLE_GKE_CLUSTER env var must be set", clusterName);
@@ -277,7 +277,7 @@ public class KubernetesEngineBuilderIT {
     gkeBuilder.setProjectId(projectId);
     gkeBuilder.setClusterName(clusterName);
     gkeBuilder.setCredentialsId(credentialsId);
-    gkeBuilder.setZone(testZone);
+    gkeBuilder.setLocation(testLocation);
     gkeBuilder.setNamespace("");
     gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_MANIFEST);
     gkeBuilder.setVerifyDeployments(true);

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderPipelineIT.java
@@ -19,6 +19,7 @@ package com.google.jenkins.plugins.k8sengine;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.copyTestFileToDir;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.formatRandomName;
+import static com.google.jenkins.plugins.k8sengine.ITUtil.getLocation;
 import static com.google.jenkins.plugins.k8sengine.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
 
@@ -58,7 +59,7 @@ public class KubernetesEngineBuilderPipelineIT {
   private static EnvVars envVars;
   private static String clusterName;
   private static String projectId;
-  private static String testZone;
+  private static String testLocation;
   private static String credentialsId;
   private static ContainerClient client;
 
@@ -69,8 +70,7 @@ public class KubernetesEngineBuilderPipelineIT {
     projectId = System.getenv("GOOGLE_PROJECT_ID");
     assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
 
-    testZone = System.getenv("GOOGLE_PROJECT_ZONE");
-    assertNotNull("GOOGLE_PROJECT_ZONE env var must be set", testZone);
+    testLocation = getLocation();
 
     clusterName = System.getenv("GOOGLE_GKE_CLUSTER");
     assertNotNull("GOOGLE_GKE_CLUSTER env var must be set", clusterName);
@@ -98,7 +98,7 @@ public class KubernetesEngineBuilderPipelineIT {
     envVars.put("PROJECT_ID", projectId);
     envVars.put("CLUSTER_NAME", clusterName);
     envVars.put("CREDENTIALS_ID", credentialsId);
-    envVars.put("ZONE", testZone);
+    envVars.put("LOCATION", testLocation);
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
   }
 
@@ -237,7 +237,7 @@ public class KubernetesEngineBuilderPipelineIT {
       String name,
       String namespace)
       throws Exception {
-    Cluster cluster = client.getCluster(projectId, testZone, clusterName);
+    Cluster cluster = client.getCluster(projectId, testLocation, clusterName);
     KubeConfig kubeConfig =
         KubeConfig.fromCluster(projectId, cluster, CredentialsUtil.getAccessToken(credentialsId));
     KubectlWrapper kubectl =

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -44,8 +44,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesEngineBuilderTest {
-  static final String TEST_ZONE_A = "us-west1-a";
-  static final String TEST_ZONE_B = "us-central1-b";
   static final String TEST_PROJECT_ID = "test-project-id";
   static final String OTHER_PROJECT_ID = "other-project-id";
   static final String TEST_CREDENTIALS_ID = "test-credentials-id";

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import com.google.api.services.container.Container;
-import com.google.api.services.container.Container.Projects.Zones.Clusters;
+import com.google.api.services.container.Container.Projects.Locations.Clusters;
 import com.google.api.services.container.model.Cluster;
 import com.google.api.services.container.model.ListClustersResponse;
 import com.google.common.collect.ImmutableList;
@@ -155,16 +155,16 @@ public class ContainerClientTest {
       throws IOException {
     Container container = Mockito.mock(Container.class);
     Container.Projects projects = Mockito.mock(Container.Projects.class);
-    Container.Projects.Zones locations = Mockito.mock(Container.Projects.Zones.class);
-    Clusters clusters = Mockito.mock(Container.Projects.Zones.Clusters.class);
+    Container.Projects.Locations locations = Mockito.mock(Container.Projects.Locations.class);
+    Clusters clusters = Mockito.mock(Container.Projects.Locations.Clusters.class);
     Mockito.when(container.projects()).thenReturn(projects);
-    Mockito.when(projects.zones()).thenReturn(locations);
+    Mockito.when(projects.locations()).thenReturn(locations);
     Mockito.when(locations.clusters()).thenReturn(clusters);
     if (getCall != null) {
-      Mockito.when(clusters.get(anyString(), anyString(), anyString())).thenReturn(getCall);
+      Mockito.when(clusters.get(anyString())).thenReturn(getCall);
     }
     if (listCall != null) {
-      Mockito.when(clusters.list(anyString(), anyString())).thenReturn(listCall);
+      Mockito.when(clusters.list(anyString())).thenReturn(listCall);
     }
     return new ContainerClient(container);
   }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ContainerClientTest.java
@@ -35,18 +35,18 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ContainerClientTest {
   private static final String TEST_PROJECT_ID = "test-project-id";
-  private static final String TEST_ZONE = "us-west1-a";
+  private static final String TEST_LOCATION = "us-west1-a";
   private static final String TEST_CLUSTER = "testCluster";
   private static final String OTHER_CLUSTER = "otherCluster";
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithNullProjectId() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
-    containerClient.getCluster(null, TEST_ZONE, TEST_CLUSTER);
+    containerClient.getCluster(null, TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testGetClustersErrorWithNullZone() throws IOException {
+  public void testGetClustersErrorWithNullLocation() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
     containerClient.getCluster(TEST_PROJECT_ID, null, TEST_CLUSTER);
   }
@@ -54,17 +54,17 @@ public class ContainerClientTest {
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithNullClusterName() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
-    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, null);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithEmptyProjectId() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
-    containerClient.getCluster("", TEST_ZONE, TEST_CLUSTER);
+    containerClient.getCluster("", TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testGetClustersErrorWithEmptyZone() throws IOException {
+  public void testGetClustersErrorWithEmptyLocation() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
     containerClient.getCluster(TEST_PROJECT_ID, "", TEST_CLUSTER);
   }
@@ -72,14 +72,14 @@ public class ContainerClientTest {
   @Test(expected = IllegalArgumentException.class)
   public void testGetClustersErrorWithEmptyClusterName() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, null);
-    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, "");
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, "");
   }
 
   @Test
   public void testGetClusterReturnsProperlyWhenClusterExists() throws IOException {
     ContainerClient containerClient = setUpGetClient(TEST_CLUSTER, null);
     Cluster expected = new Cluster().setName(TEST_CLUSTER);
-    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, TEST_CLUSTER);
+    Cluster response = containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
     assertNotNull(response);
     assertEquals(expected, response);
   }
@@ -87,7 +87,7 @@ public class ContainerClientTest {
   @Test(expected = IOException.class)
   public void testGetClusterThrowsErrorWhenClusterDoesntExists() throws IOException {
     ContainerClient containerClient = setUpGetClient(null, new IOException());
-    containerClient.getCluster(TEST_PROJECT_ID, TEST_ZONE, TEST_CLUSTER);
+    containerClient.getCluster(TEST_PROJECT_ID, TEST_LOCATION, TEST_CLUSTER);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -147,7 +147,7 @@ public class ContainerClientTest {
 
   private static List<Cluster> initClusterList(List<String> clusterNames) {
     List<Cluster> clusters = new ArrayList<>();
-    clusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setZone(TEST_ZONE)));
+    clusterNames.forEach(e -> clusters.add(new Cluster().setName(e).setLocation(TEST_LOCATION)));
     return clusters;
   }
 
@@ -155,11 +155,11 @@ public class ContainerClientTest {
       throws IOException {
     Container container = Mockito.mock(Container.class);
     Container.Projects projects = Mockito.mock(Container.Projects.class);
-    Container.Projects.Zones zones = Mockito.mock(Container.Projects.Zones.class);
+    Container.Projects.Zones locations = Mockito.mock(Container.Projects.Zones.class);
     Clusters clusters = Mockito.mock(Container.Projects.Zones.Clusters.class);
     Mockito.when(container.projects()).thenReturn(projects);
-    Mockito.when(projects.zones()).thenReturn(zones);
-    Mockito.when(zones.clusters()).thenReturn(clusters);
+    Mockito.when(projects.zones()).thenReturn(locations);
+    Mockito.when(locations.clusters()).thenReturn(clusters);
     if (getCall != null) {
       Mockito.when(clusters.get(anyString(), anyString(), anyString())).thenReturn(getCall);
     }

--- a/src/test/resources/com/google/jenkins/plugins/k8sengine/gitDeclarativePipeline.groovy
+++ b/src/test/resources/com/google/jenkins/plugins/k8sengine/gitDeclarativePipeline.groovy
@@ -22,7 +22,7 @@ pipeline {
         }
         stage('Deploy') {
             steps{
-                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, zone: env.ZONE, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
+                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, location: env.LOCATION, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
             }
         }
     }

--- a/src/test/resources/com/google/jenkins/plugins/k8sengine/malformedDeclarativePipeline.groovy
+++ b/src/test/resources/com/google/jenkins/plugins/k8sengine/malformedDeclarativePipeline.groovy
@@ -17,7 +17,7 @@ pipeline {
     stages {
         stage('Deploy') {
             steps{
-                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, zone: env.ZONE, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
+                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, location: env.LOCATION, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
             }
         }
     }

--- a/src/test/resources/com/google/jenkins/plugins/k8sengine/noNamespaceDeclarativePipeline.groovy
+++ b/src/test/resources/com/google/jenkins/plugins/k8sengine/noNamespaceDeclarativePipeline.groovy
@@ -17,7 +17,7 @@ pipeline {
     stages {
         stage('Deploy') {
             steps{
-                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, zone: env.ZONE, /* namespace: null,*/ manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
+                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, location: env.LOCATION, /* namespace: null,*/ manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
             }
         }
     }

--- a/src/test/resources/com/google/jenkins/plugins/k8sengine/workspaceDeclarativePipeline.groovy
+++ b/src/test/resources/com/google/jenkins/plugins/k8sengine/workspaceDeclarativePipeline.groovy
@@ -17,7 +17,7 @@ pipeline {
     stages {
         stage('Deploy') {
             steps{
-                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, zone: env.ZONE, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
+                step([$class: 'KubernetesEngineBuilder', projectId: env.PROJECT_ID, clusterName: env.CLUSTER_NAME, location: env.LOCATION, namespace: env.NAMESPACE, manifestPattern: env.MANIFEST_PATTERN, credentialsId: env.CREDENTIALS_ID, verifyDeployments: true])
             }
         }
     }


### PR DESCRIPTION
Note: develop as it stands now has one minor bug which this change fixes. It is possible to select a regional cluster from the dropdown because the "-" wild card retrieves regional clusters from the Containers.Projects.Zones.Clusters.List API call, and the value of `getZone()` for a regional cluster is the region name. However, it is not possible to use the Containers.Projects.Zones.Clusters.Get API call with a region name in place of a zone name, which means we can't get the kube config to deploy.

Testing:
1. Running `mvn verify` with `GOOGLE_PROJECT_ZONE` set and with/without `GOOGLE_PROJECT_LOCATION` set, both as a zone and a region.
1. Created build step with the current develop branch snapshot, then with the snapshot from these changes deployed successfully.
1. Opened the configuration page for the build step from 1 with the new snapshot, and all elements loaded properly without errors. Pressed submit and saved with no errors.
 1. Selected a regional cluster from the drop down. Saved the build step config, and deployed successfully.