### PR TITLE
Format and tidy pom file after release preparation completes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.37</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <artifactId>google-kubernetes-engine</artifactId>
@@ -268,6 +268,13 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <completionGoals>xml-format:xml-format tidy:pom</completionGoals>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.8</version>
@@ -318,7 +325,7 @@
         <version>2.7</version>
         <configuration>
           <instrumentation>
-            <excludes />
+            <excludes/>
           </instrumentation>
           <formats>
             <format>html</format>


### PR DESCRIPTION
This occurs after the pom file is modified but before being committed by the release plugin and will prevent the back and forth that keeps happening after releases.