### PR TITLE
Update to version 21.0 of guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>google-kubernetes-engine</artifactId>
-  <version>0.7.2-SNAPSHOT</version>
+  <version>0.8.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Google Kubernetes Engine Plugin</name>
@@ -68,8 +68,11 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
-    <!-- TODO: Update to a newer api version when Jenkins core is not bundled with guava 11. -->
-    <google-api-client.version>1.24.1</google-api-client.version>
+    <google.guava.version>20.0</google.guava.version>
+    <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
+    <google-oauth-plugin.version>1.0.0-SNAPSHOT</google-oauth-plugin.version>
+    <hpi.compatibleSinceVersion>0.8.0</hpi.compatibleSinceVersion>
+    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
   </properties>
 
   <dependencies>
@@ -122,7 +125,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
-      <version>0.9</version>
+      <version>${google-oauth-plugin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>
@@ -149,22 +152,12 @@
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>
       <artifactId>gcp-client</artifactId>
-      <version>0.1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api-client</groupId>
-      <artifactId>google-api-client</artifactId>
-      <version>${google-api-client.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <version>${google-api-client.version}</version>
+      <version>${gcp-plugin-core.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${google.guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -175,11 +168,6 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.4.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.8.5</version>
     </dependency>
     <dependency>
       <groupId>io.projectreactor</groupId>
@@ -307,6 +295,7 @@
         <configuration>
           <disableXmlReport>true</disableXmlReport>
           <useFile>false</useFile>
+          <skipITs>${skip.surefire.tests}</skipITs>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
     <google.guava.version>20.0</google.guava.version>
+    <google.api.version>1.25.0</google.api.version>
+    <google.http.version>1.21.0</google.http.version>
+    <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
+    <container.revision>74</container.revision>
     <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
     <google-oauth-plugin.version>1.0.0-SNAPSHOT</google-oauth-plugin.version>
     <hpi.compatibleSinceVersion>0.8.0</hpi.compatibleSinceVersion>
@@ -158,6 +162,49 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${google.guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google.http.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudresourcemanager</artifactId>
+      <version>v1-rev${cloudresourcemanager.revision}-${google.api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-container</artifactId>
+      <version>v1-rev${container.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <google.http.version>1.21.0</google.http.version>
     <cloudresourcemanager.revision>547</cloudresourcemanager.revision>
     <container.revision>74</container.revision>
-    <gcp-plugin-core.version>0.2.0-SNAPSHOT</gcp-plugin-core.version>
-    <google-oauth-plugin.version>1.0.0-SNAPSHOT</google-oauth-plugin.version>
+    <gcp-plugin-core.version>0.2.0</gcp-plugin-core.version>
+    <google-oauth-plugin.version>1.0.0</google-oauth-plugin.version>
     <hpi.compatibleSinceVersion>0.8.0</hpi.compatibleSinceVersion>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
   </properties>

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/CredentialsUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/CredentialsUtilTest.java
@@ -9,7 +9,6 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.k8sengine.client.ContainerScopeRequirement;
@@ -77,14 +76,14 @@ public class CredentialsUtilTest {
 
   @Test(expected = IOException.class)
   public void testGetAccessTokenIOException() throws IOException {
-    GoogleCredential googleCredential = Mockito.mock(GoogleCredential.class);
+    Credential googleCredential = Mockito.mock(Credential.class);
     Mockito.when(googleCredential.refreshToken()).thenThrow(IOException.class);
     CredentialsUtil.getAccessToken(googleCredential);
   }
 
   @Test
   public void testGetAccessTokenReturnsToken() throws IOException {
-    GoogleCredential googleCredential = Mockito.mock(GoogleCredential.class);
+    Credential googleCredential = Mockito.mock(Credential.class);
     Mockito.when(googleCredential.refreshToken()).thenReturn(true);
     Mockito.when(googleCredential.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
     String accessToken = CredentialsUtil.getAccessToken(googleCredential);
@@ -125,7 +124,7 @@ public class CredentialsUtilTest {
 
   @Test(expected = NullPointerException.class)
   public void testGetAccessTokenWithNullGoogleCredential() throws IOException {
-    GoogleCredential googleCredential = null;
+    Credential googleCredential = null;
     CredentialsUtil.getAccessToken(googleCredential);
   }
 }


### PR DESCRIPTION
Depends on upstream changes and releases:
- [x] Change: https://github.com/jenkinsci/google-oauth-plugin/pull/75
- [x] Release 1.0.0 of google-oauth-plugin
- [x] https://github.com/GoogleCloudPlatform/gcp-plugin-core-java/pull/9
- [x] Release 0.2.0 of gcp-plugin-core-java
