### PR TITLE
Prevent ITs from being executed by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
 	    	        sh "mvn clean package -ntp"
 
 		        // run tests
-		        sh "mvn verify -ntp"
+		        sh "mvn verify -ntp -DskipITs=false"
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <google-oauth-plugin.version>1.0.0</google-oauth-plugin.version>
     <hpi.compatibleSinceVersion>0.8.0</hpi.compatibleSinceVersion>
     <skip.surefire.tests>${skipTests}</skip.surefire.tests>
+    <skipITs>true</skipITs>
   </properties>
 
   <dependencies>
@@ -342,7 +343,7 @@
         <configuration>
           <disableXmlReport>true</disableXmlReport>
           <useFile>false</useFile>
-          <skipITs>${skip.surefire.tests}</skipITs>
+          <skipITs>${skipITs}</skipITs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR is similar to https://github.com/jenkinsci/google-compute-engine-plugin/pull/160
I've opened the PR against `develop` since it's the default branch. If I should have done it against `master` branch, please let me know and I'll be happy to change the PR.

In the same way any other plugin in the community can be installed locally without configuring any external system, this plugin should allow to do the same. However, if I execute a mvn verify or mvn install I get errors because the integration tests are executed and I don't have any configured GCE instance.

This PR pretends to make possible the local installation of the plugin giving as well a mechanism that allows to execute those integration tests. In this case, I haven't updated the documentation as I haven't seen a proper place to do it. If needed, please point me to the section where I can document this change.

@evandbrown @craigdbarber @stephenashank 