### PR TITLE
Update parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.37</version>
+    <version>4.7</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
The current parent pom has a bug resulting in transitive dependencies from plugin dependencies being bundled. This update fixes that.