### PR TITLE
Hacktoberfest - Rename jenkinsci/jnlp-slave and jenkins/jnlp-slave -> jenkins/inbound-agent

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -237,7 +237,7 @@ pipeline {
 ### Jenkins Environment Configuration
 
 <!--- TODO(stephenshank): Link to an image that adds kubectl to the existing jenkins agent image:
-      https://hub.docker.com/r/jenkinsci/jnlp-slave/ --->
+      https://hub.docker.com/r/jenkins/inbound-agent/ --->
 
 The GKE Jenkins plugin requires the [kubectl](
 https://kubernetes.io/docs/tasks/tools/install-kubectl/) binary to be installed within the Jenkins

--- a/jenkinsagent/Dockerfile
+++ b/jenkinsagent/Dockerfile
@@ -9,7 +9,7 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 # implied. See the License for the specific language governing permissions and limitations under the
 # License.
-FROM jenkins/jnlp-slave
+FROM jenkins/inbound-agent
 
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https


### PR DESCRIPTION
As mentioned in https://www.jenkins.io/blog/2020/05/06/docker-agent-image-renaming/ and https://issues.jenkins-ci.org/browse/JENKINS-42846