### PR TITLE
[JENKINS-62899] Removing table markup in configuration page

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder/config.jelly
@@ -30,17 +30,15 @@
         <f:textbox/>
     </f:entry>
     <f:block>
-      <table>
-        <f:optionalBlock field="verifyDeployments" title="Verify Deployments" checked="${it.verifyDeployments}" inline="true">
-           <!-- TODO(johnlabarge): add once serivce verification implemented (verifying services requires verifying deployments).
-              <f:entry field="verifyServices" title="${%Verify Services}">
-                  <f:checkbox name="verifyServices" checked="${it.verifyServices}"/>
-              </f:entry>
-           -->
-          <f:entry field="verifyTimeoutInMinutes" title="${%Verify Timeout in Minutes}">
-            <f:textbox type="number" default="5"/>
-          </f:entry>
-        </f:optionalBlock>
-      </table>
+      <f:optionalBlock field="verifyDeployments" title="Verify Deployments" checked="${it.verifyDeployments}" inline="true">
+         <!-- TODO(johnlabarge): add once serivce verification implemented (verifying services requires verifying deployments).
+            <f:entry field="verifyServices" title="${%Verify Services}">
+                <f:checkbox name="verifyServices" checked="${it.verifyServices}"/>
+            </f:entry>
+         -->
+        <f:entry field="verifyTimeoutInMinutes" title="${%Verify Timeout in Minutes}">
+          <f:textbox type="number" default="5"/>
+        </f:entry>
+      </f:optionalBlock>
     </f:block>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-62899](https://issues.jenkins.io/browse/JENKINS-62899)

In my local tests, the `<table/>` was not providing any help in the display of the field. Removing it didn't break the display with the default `jenkins.version` and was fine when running with `2.265`.

This PR fixes the plugin when used with https://github.com/jenkinsci/jenkins/pull/3895