### PR TITLE
Update snakeyaml to 1.27 using the plugin api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: "2.204.6" ],
-    [ platform: "linux", jdk: "11", jenkins: "2.204.6", javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: "2.204.6", javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
+    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [ platform: "linux", jdk: "8", jenkins: "2.204.6" ],
+    [ platform: "linux", jdk: "11", jenkins: "2.204.6", javaLevel: "8" ],
+    [ platform: "windows", jdk: "8", jenkins: "2.204.6", javaLevel: "8" ],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,1 @@
-buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
-])
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
   </scm>
 
   <properties>
-    <!-- It needs to be .6 at least -->
-    <jenkins.version>2.204.6</jenkins.version>
+    <!-- It needs to be .6 at least because of SnakeYaml -->
+    <jenkins.version> 2.204.6</jenkins.version>
     <java.level>8</java.level>
     <java.level.test>8</java.level.test>
     <google.guava.version>24.1.1-jre</google.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,10 @@
       <version>v1-rev${container.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>snakeyaml-api</artifactId>
-        <version>1.27.0</version>
-        <type>hpi</type>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>snakeyaml-api</artifactId>
+      <version>1.27.0</version>
+      <type>hpi</type>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,10 @@
   </scm>
 
   <properties>
-    <jenkins.version> 2.204.6</jenkins.version>
+    <!-- It needs to be .6 at least -->
+    <jenkins.version>2.204.6</jenkins.version>
     <java.level>8</java.level>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
+    <java.level.test>8</java.level.test>
     <google.guava.version>24.1.1-jre</google.guava.version>
     <google.api.version>1.25.0</google.api.version>
     <google.http.version>1.21.0</google.http.version>
@@ -75,31 +74,35 @@
     <container.revision>74</container.revision>
     <gcp-plugin-core.version>0.2.0</gcp-plugin-core.version>
     <google-oauth-plugin.version>1.0.0</google-oauth-plugin.version>
-    <hpi.compatibleSinceVersion>0.8.0</hpi.compatibleSinceVersion>
-    <skip.surefire.tests>${skipTests}</skip.surefire.tests>
-    <skipITs>true</skipITs>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.204.x</artifactId>
+        <version>18</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.17</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -109,23 +112,20 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.8</version>
+      <version>2.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>${pipeline-model-definition.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>3.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -135,24 +135,20 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>
@@ -163,6 +159,14 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${google.guava.version}</version>
+      <exclusions>
+        <!-- We use the one from git:4.4.5: 2.3.4. Newer than
+             the one here: 2.1.3 -->
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
@@ -210,7 +214,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
-      <version>1.27.0</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
@@ -226,6 +229,13 @@
       <groupId>io.projectreactor.addons</groupId>
       <artifactId>reactor-extra</artifactId>
       <version>3.2.2.RELEASE</version>
+    </dependency>
+    <!-- Required for InjectedTest. Git 4.4.5 for org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.18</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,8 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <version>1.27.0</version>
-    <dependency>
+    </dependency>
+   <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.4.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,6 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>snakeyaml-api</artifactId>
       <version>1.27.0</version>
-      <type>hpi</type>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.164.2</jenkins.version>
+    <jenkins.version> 2.204.6</jenkins.version>
     <java.level>8</java.level>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,10 @@
       <version>v1-rev${container.revision}-${google.api.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>1.19</version>
-    </dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>snakeyaml-api</artifactId>
+        <version>1.27.0</version>
+        <type>hpi</type>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
       <artifactId>snakeyaml-api</artifactId>
       <version>1.27.0</version>
     </dependency>
-   <dependency>
+    <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.4.0</version>


### PR DESCRIPTION
Bump SnakeYaml to 1.27 using the Jenkins plugin instead of the library directly.
Depends on https://github.com/jenkinsci/google-kubernetes-engine-plugin/pull/138 to allow the CI run.

cc: @alecharp @batmat @rsandell @fqueiruga @Wadeck 