### PR TITLE
Specify the jenkins version to run in

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: "2.204.6" ],
-    [ platform: "linux", jdk: "11", jenkins: "2.204.6", javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: "2.204.6", javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
+    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [ platform: "linux", jdk: "8", jenkins: "2.204.6" ],
+    [ platform: "linux", jdk: "11", jenkins: "2.204.6", javaLevel: "8" ],
+    [ platform: "windows", jdk: "8", jenkins: "2.204.6", javaLevel: "8" ],
+])


### PR DESCRIPTION
If it helps, I file a new PR to just modify the Jenkinsfile. I believe this change is not taking into account unless it comes from a person with write permission. We let the CI use the specified jenkins.version in the pom.xml, instead of using  2.164.1 from `recommendedConfigurations`, which is too old for the dependencies we have after bumping snakeyaml.

Used the version needed by SnakeYaml 1.27 on #134 