### PR TITLE
Add deployments resource to the robot-deployer cluster role

### DIFF
--- a/docs/rbac/robot-deployer.yaml
+++ b/docs/rbac/robot-deployer.yaml
@@ -13,6 +13,7 @@ rules:
   - endpoints
   - services
   - pods
+  - deployments
   verbs:
   - create
   - get


### PR DESCRIPTION
In my testing, the cluster role also needed access to the `deployments` resource.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
