### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>


### PR DESCRIPTION
The old `git://` protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).