### PR TITLE
Improve verifications to verify rollout deployments

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiers.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiers.java
@@ -137,9 +137,11 @@ public class KubernetesVerifiers {
      * available replicas (status.availableReplicas).
      */
     private static class DeploymentVerifier implements Verifier {
-        private static final String AVAILABLE_REPLICAS = "availableReplicas";
-        private static final String MINIMUM_REPLICAS_JSONPATH = "spec.replicas";
         private static final String STATUS_JSONPATH = "status";
+        private static final String AVAILABLE_REPLICAS = "availableReplicas";
+        private static final String UPDATED_REPLICAS = "updatedReplicas";
+        private static final String REPLICAS = "replicas";
+        private static final String DESIRED_REPLICAS_JSONPATH = "spec.replicas";
 
         /**
          * Verifies that the deployment was applied to the GKE cluster.
@@ -162,18 +164,24 @@ public class KubernetesVerifiers {
                 return errorResult(e, object);
             }
 
-            Integer minReplicas = JsonPath.read(json, MINIMUM_REPLICAS_JSONPATH);
+            Integer desiredReplicas = JsonPath.read(json, DESIRED_REPLICAS_JSONPATH);
             Map<String, Object> status = JsonPath.read(json, STATUS_JSONPATH);
             Integer availableReplicas = (Integer) status.getOrDefault(AVAILABLE_REPLICAS, 0);
-            boolean verified = minReplicas != null
-                    && availableReplicas != null
-                    && minReplicas.intValue() <= availableReplicas.intValue();
+            Integer updatedReplicas = (Integer) status.getOrDefault(UPDATED_REPLICAS, 0);
+            Integer replicas = (Integer) status.getOrDefault(REPLICAS, 0);
+            boolean verified = desiredReplicas != null
+                    && updatedReplicas.intValue() >= desiredReplicas.intValue()
+                    && replicas.intValue() <= updatedReplicas.intValue()
+                    && availableReplicas.intValue() == updatedReplicas.intValue();
 
             log.append("AvailableReplicas = ")
                     .append(availableReplicas)
                     .append(",")
-                    .append(" MinimumReplicas = ")
-                    .append(minReplicas)
+                    .append(" UpdatedReplicas = ")
+                    .append(updatedReplicas)
+                    .append(",")
+                    .append(" DesiredReplicas = ")
+                    .append(desiredReplicas)
                     .append("\n");
 
             return new VerificationResult(log.toString(), verified, object);

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
@@ -76,7 +76,8 @@ public class VerificationTask {
      * @return Self-reference after performing verify.
      */
     private VerificationTask verify() {
-        consoleLogger.println(String.format("Verifying: %s ", manifestObject.describe()));
+        consoleLogger.println(
+                Messages.KubernetesEngineBuilder_VerifyingLogPrefix(manifestObject.describe()));
         currentResult = KubernetesVerifiers.verify(kubectl, manifestObject);
         if (isVerified()) {
             consoleLogger.println(currentResult.toString());

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
@@ -76,8 +76,7 @@ public class VerificationTask {
      * @return Self-reference after performing verify.
      */
     private VerificationTask verify() {
-        consoleLogger.println(
-                Messages.KubernetesEngineBuilder_VerifyingLogPrefix(manifestObject.describe()));
+        consoleLogger.println(Messages.KubernetesEngineBuilder_VerifyingLogPrefix(manifestObject.describe()));
         currentResult = KubernetesVerifiers.verify(kubectl, manifestObject);
         if (isVerified()) {
             consoleLogger.println(currentResult.toString());

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
@@ -44,9 +44,12 @@ public class KubernetesVerifiersTest {
         KubernetesVerifiers.VerificationResult result = KubernetesVerifiers.verify(kubectl, goodDeployment);
         assertTrue(result.isVerified());
         Integer availableReplicas = JsonPath.read(goodDeploymentOutput, "status.availableReplicas");
-        Integer minimumReplicas = JsonPath.read(goodDeploymentOutput, "spec.replicas");
+        Integer updatedReplicas = JsonPath.read(goodDeploymentOutput, "status.updatedReplicas");
+        Integer desiredReplicas = JsonPath.read(goodDeploymentOutput, "spec.replicas");
         String shouldBeInLog =
-                String.format("AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
+                String.format(
+                        "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
+                        availableReplicas, updatedReplicas, desiredReplicas);
         String verificationLog = result.toString();
         assertTrue(verificationLog.contains(shouldBeInLog));
     }
@@ -65,10 +68,13 @@ public class KubernetesVerifiersTest {
         KubernetesVerifiers.VerificationResult result = KubernetesVerifiers.verify(kubectl, badDeployment);
         assertFalse(result.isVerified());
 
-        Integer minimumReplicas = JsonPath.read(badDeploymentOutput, "spec.replicas");
+        Integer desiredReplicas = JsonPath.read(badDeploymentOutput, "spec.replicas");
+        Integer updatedReplicas = JsonPath.read(badDeploymentOutput, "status.updatedReplicas");
         Integer availableReplicas = 0;
         String shouldBeInLog =
-                String.format("AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
+                String.format(
+                        "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
+                        availableReplicas, updatedReplicas, desiredReplicas);
         String verificationLog = result.toString();
         assertTrue(verificationLog.contains(shouldBeInLog));
     }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
@@ -46,10 +46,9 @@ public class KubernetesVerifiersTest {
         Integer availableReplicas = JsonPath.read(goodDeploymentOutput, "status.availableReplicas");
         Integer updatedReplicas = JsonPath.read(goodDeploymentOutput, "status.updatedReplicas");
         Integer desiredReplicas = JsonPath.read(goodDeploymentOutput, "spec.replicas");
-        String shouldBeInLog =
-                String.format(
-                        "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
-                        availableReplicas, updatedReplicas, desiredReplicas);
+        String shouldBeInLog = String.format(
+                "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
+                availableReplicas, updatedReplicas, desiredReplicas);
         String verificationLog = result.toString();
         assertTrue(verificationLog.contains(shouldBeInLog));
     }
@@ -71,10 +70,9 @@ public class KubernetesVerifiersTest {
         Integer desiredReplicas = JsonPath.read(badDeploymentOutput, "spec.replicas");
         Integer updatedReplicas = JsonPath.read(badDeploymentOutput, "status.updatedReplicas");
         Integer availableReplicas = 0;
-        String shouldBeInLog =
-                String.format(
-                        "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
-                        availableReplicas, updatedReplicas, desiredReplicas);
+        String shouldBeInLog = String.format(
+                "AvailableReplicas = %s, UpdatedReplicas = %s, DesiredReplicas = %s",
+                availableReplicas, updatedReplicas, desiredReplicas);
         String verificationLog = result.toString();
         assertTrue(verificationLog.contains(shouldBeInLog));
     }


### PR DESCRIPTION
This PR uses the [same algorithm](https://github.com/kubernetes/kubectl/blob/f89fc21e9c51d313e923eb93d1ae83754be62019/pkg/polymorphichelpers/rollout_status.go#L80-L88) as "kubectl rollout status" for the verification of rollout deployments.

Fixes https://github.com/jenkinsci/google-kubernetes-engine-plugin/issues/119

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
