### PR TITLE
Forward compatibility with SnakeYAML 2.0

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/k8sengine/Manifests.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/Manifests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -37,7 +38,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 public class Manifests {
   private static final String DEFAULT_ENCODING = "UTF-8";
 
-  static Yaml yaml = new Yaml(new SafeConstructor());
+  static Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
   private List<ManifestObject> objects = new ArrayList<ManifestObject>();
 
   /** ManifestObject wrapper that encapsulates an object spec loaded from a supplied manifest. */

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -108,7 +109,7 @@ public class KubeConfigTest {
   }
 
   private static boolean yamlEquals(String expectedYaml, String testYaml) throws IOException {
-    Yaml yaml = new Yaml(new SafeConstructor());
+    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
     Map<String, Object> testConfig = yaml.load(new BufferedReader(new StringReader(testYaml)));
     Map<String, Object> expectedConfig =
         yaml.load(new BufferedReader(new StringReader(expectedYaml)));


### PR DESCRIPTION
Without dropping support for SnakeYAML 1.33, add support for SnakeYAML 2.0. The only difference is that a few deprecated constructors were deleted. Resolved the problem by inlining the deleted code, which does not change any behavior. Tested locally with both versions of SnakeYAML.