### PR TITLE
Build on container agents & remove deprecated options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(useContainerAgent: true, configurations: [
     [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
+    [ platform: "linux", jdk: "11", jenkins: null ],
+    [ platform: "windows", jdk: "8", jenkins: null ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
     [ platform: "linux", jdk: "8", jenkins: null ],
     [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
     [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge once the changes on ci.jenkins.io are live, to prevent failures on the master branch and new PRs.