### PR TITLE
Update `Jenkinsfile` syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
-    [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ],
-    [ platform: "windows", jdk: "8", jenkins: null, javaLevel: "8" ],
+    [platform: 'linux', jdk: 8],
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 8],
 ])


### PR DESCRIPTION
The `javaLevel` option is deprecated and no longer sets the Java version. The option is ignored. This PR removes the unused option.