### PR TITLE
Enabling cd for automated plugin releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,2 +1,1 @@
 _extends: .github
-tag-template: google-kubernetes-engine-$NEXT_MINOR_VERSION

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,15 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>google-kubernetes-engine</artifactId>
-  <version>0.8.10-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Google Kubernetes Engine Plugin</name>
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <revision>0.8.8</revision>
+    <revision>0.8.10</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-kubernetes-engine-plugin</gitHubRepo>
     <jenkins.version>2.346.1</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <revision>0</revision>
-    <changelist>-SNAPSHOT</changelist>
+    <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-kubernetes-engine-plugin</gitHubRepo>
     <jenkins.version>2.346.1</jenkins.version>
     <google.guava.version>30.1-jre</google.guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </parent>
 
   <artifactId>google-kubernetes-engine</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Google Kubernetes Engine Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
   </scm>
 
   <properties>
-    <revision>0.8.10</revision>
+    <revision>0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/google-kubernetes-engine-plugin</gitHubRepo>
     <jenkins.version>2.346.1</jenkins.version>


### PR DESCRIPTION

I am enabling automated releases in this repo to make it easier to ensure merged PRs make it into a new release in a timely fashion.

I am following: https://www.jenkins.io/doc/developer/publishing/releasing-cd/
This is the first step for [Incrementals Enablement](https://www.jenkins.io/doc/developer/publishing/releasing-cd/#incrementals-enablement)

When following https://www.jenkins.io/doc/developer/plugin-development/incrementals/, I noticed that some of the files already existed in this repository. Could you please double check the revision number I changed on the pom.xml is correct (along with the other changes)? 🙂 

I also changed the incrementals version to be the newest version [here](https://github.com/jenkinsci/incrementals-tools).

Many thanks


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```