### PR TITLE
Removed 3 unnecessary stubbings from KubernetesEngineBuilderClusterTest.java

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
@@ -58,7 +58,7 @@ public class KubernetesEngineBuilderClusterTest {
 
   @Test
   public void testDoFillClusterItemsEmptyWithEmptyCredentialsId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+    DescriptorImpl descriptor = setUpClusterDescriptor3(ImmutableList.of(), null, null);
     ListBoxModel expected =
         initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
     ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, null, TEST_PROJECT_ID);
@@ -68,7 +68,7 @@ public class KubernetesEngineBuilderClusterTest {
 
   @Test
   public void testDoFillClusterItemsEmptyWithEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+    DescriptorImpl descriptor = setUpClusterDescriptor3(ImmutableList.of(), null, null);
     ListBoxModel expected =
         initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
     ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, null);
@@ -184,7 +184,7 @@ public class KubernetesEngineBuilderClusterTest {
 
   @Test
   public void testDoCheckClusterMessageWithEmptyCredentialsId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+    DescriptorImpl descriptor = setUpClusterDescriptor3(ImmutableList.of(), null, null);
     FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, null, TEST_PROJECT_ID);
     assertNotNull(result);
     assertEquals(
@@ -193,7 +193,7 @@ public class KubernetesEngineBuilderClusterTest {
 
   @Test
   public void testDoCheckClusterMessageWithEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+    DescriptorImpl descriptor = setUpClusterDescriptor2(ImmutableList.of(), null, null);
     FormValidation result =
         descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, null);
     assertNotNull(result);
@@ -287,6 +287,51 @@ public class KubernetesEngineBuilderClusterTest {
     initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
     Mockito.when(containerClient.listAllClusters(anyString()))
         .thenReturn(ImmutableList.copyOf(clusters));
+    return descriptor;
+  }
+
+  private DescriptorImpl setUpClusterDescriptor2(
+      List<String> initialClusters, AbortException abortException, IOException ioException)
+      throws IOException {
+    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+    if (abortException != null) {
+      Mockito.doThrow(abortException)
+          .when(descriptor)
+          .getClientFactory(any(Jenkins.class), anyString());
+      return descriptor;
+    }
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    Mockito.doReturn(clientFactory)
+        .when(descriptor)
+        .getClientFactory(any(Jenkins.class), anyString());
+    ContainerClient containerClient = Mockito.mock(ContainerClient.class);
+    if (ioException != null) {
+      Mockito.when(containerClient.listAllClusters(anyString())).thenThrow(ioException);
+      return descriptor;
+    }
+    List<Cluster> clusters = new ArrayList<>();
+    initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
+    return descriptor;
+  }
+
+  private DescriptorImpl setUpClusterDescriptor3(
+      List<String> initialClusters, AbortException abortException, IOException ioException)
+      throws IOException {
+    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+    if (abortException != null) {
+      Mockito.doThrow(abortException)
+          .when(descriptor)
+          .getClientFactory(any(Jenkins.class), anyString());
+      return descriptor;
+    }
+    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+    ContainerClient containerClient = Mockito.mock(ContainerClient.class);
+    if (ioException != null) {
+      Mockito.when(containerClient.listAllClusters(anyString())).thenThrow(ioException);
+      return descriptor;
+    }
+    List<Cluster> clusters = new ArrayList<>();
+    initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
     return descriptor;
   }
 }


### PR DESCRIPTION


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

In our analysis of the project, we observed that 
1) 2 unnecessary stubbings which stubbed `containerClient` method and `listAllClusters` method in `setUpClusterDescriptor` are created but are never executed by the test `KubernetesEngineBuilderClusterTest.testDoCheckClusterMessageWithEmptyProjectId`; 
2) 3 unnecessary stubbings which stubbed `getClientFactory` method, `containerClient` method and `listAllClusters` method in `setUpClusterDescriptor` are created but are never executed by 3 tests `KubernetesEngineBuilderClusterTest.testDoFillClusterItemsEmptyWithEmptyCredentialsId`, `KubernetesEngineBuilderClusterTest.testDoFillClusterItemsEmptyWithEmptyProjectId`,`KubernetesEngineBuilderClusterTest.testDoCheckClusterMessageWithEmptyCredentialsId`. 

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.
