### PR TITLE
Remove unnecessary JARs from HPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,10 +92,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
@@ -133,10 +129,6 @@
       <artifactId>google-oauth-plugin</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>annotation-indexer</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -165,6 +157,11 @@
           <artifactId>httpclient</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by core -->
+        <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
@@ -190,6 +187,7 @@
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
+        <!-- Provided by core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
@@ -214,6 +212,13 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.8.0</version>
+      <exclusions>
+        <!-- Provided by core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.projectreactor</groupId>

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2Credentials;
 import com.google.jenkins.plugins.k8sengine.client.ClientUtil;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -57,7 +58,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
@@ -236,10 +236,10 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
   /** {@inheritDoc} */
   @Override
   public void perform(
-      @Nonnull Run<?, ?> run,
-      @Nonnull FilePath workspace,
-      @Nonnull Launcher launcher,
-      @Nonnull TaskListener listener)
+      @NonNull Run<?, ?> run,
+      @NonNull FilePath workspace,
+      @NonNull Launcher launcher,
+      @NonNull TaskListener listener)
       throws InterruptedException, IOException {
     LOGGER.log(
         Level.INFO,
@@ -363,7 +363,7 @@ public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep,
     private String defaultProjectId;
     private String credentialsId;
 
-    @Nonnull
+    @NonNull
     @Override
     public String getDisplayName() {
       return Messages.KubernetesEngineBuilder_DisplayName();

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/VerificationTask.java
@@ -14,13 +14,13 @@
 
 package com.google.jenkins.plugins.k8sengine;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.PrintStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -96,9 +96,9 @@ public class VerificationTask {
    * @return If the {@link Manifests.ManifestObject}'s were successfully verified.
    */
   public static boolean verifyObjects(
-      @Nonnull KubectlWrapper kubectl,
-      @Nonnull List<Manifests.ManifestObject> manifestObjects,
-      @Nonnull PrintStream consoleLogger,
+      @NonNull KubectlWrapper kubectl,
+      @NonNull List<Manifests.ManifestObject> manifestObjects,
+      @NonNull PrintStream consoleLogger,
       int timeoutInMinutes) {
     List<VerificationTask> verificationTasks =
         manifestObjects.stream()


### PR DESCRIPTION
Stop bundling these unnecessary JARs:

- `WEB-INF/lib/annotation-indexer-1.17.jar`
- `WEB-INF/lib/commons-io-2.11.0.jar`
- `WEB-INF/lib/jsr305-3.0.1.jar`
- `WEB-INF/lib/slf4j-api-2.0.6.jar`

Annotation indexer is only needed at build time, not runtime. Commons IO is provided by core. Rather than JSR 305 we use SpotBugs annotations as is the standard in all Jenkins plugins. SLF4J's API is provided by core.