### PR TITLE
Use Jenkins project-wide formatter configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,26 +14,26 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.72</version>
-    <relativePath/>
+    <version>4.76</version>
+    <relativePath />
   </parent>
 
   <artifactId>google-kubernetes-engine</artifactId>
   <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
-
   <name>Google Kubernetes Engine Plugin</name>
   <description>This plugin allows Jenkins to publish build artifacts to Kubernetes clusters running on Google Kubernetes Engine.</description>
   <!-- Jenkins CI hosting -->
   <url>https://github.com/jenkinsci/google-kubernetes-engine-plugin</url>
+
   <organization>
     <name>Google</name>
     <url>https://www.google.com</url>
   </organization>
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -58,8 +58,8 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <properties>
@@ -72,15 +72,11 @@
     <cloudresourcemanager.revision>572</cloudresourcemanager.revision>
     <container.revision>93</container.revision>
     <gcp-plugin-core.version>0.3.0</gcp-plugin-core.version>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.10.1</version>
-      </dependency>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
@@ -88,77 +84,45 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.10.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-cloudresourcemanager</artifactId>
+      <version>v1-rev${cloudresourcemanager.revision}-${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.api-client</groupId>
+          <artifactId>google-api-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>display-url-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-definition</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>google-oauth-plugin</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-container</artifactId>
+      <version>v1-rev${container.revision}-${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.api-client</groupId>
+          <artifactId>google-api-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.graphite</groupId>
       <artifactId>gcp-client</artifactId>
       <version>${gcp-plugin-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <version>${google.http.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
+          <groupId>com.google.api-client</groupId>
+          <artifactId>google-api-client</artifactId>
         </exclusion>
         <!-- Provided by core -->
         <exclusion>
@@ -169,9 +133,39 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google.http.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <!-- Provided by core -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <!-- Provided by apache-httpcomponents-client-4-api plugin -->
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
       <version>1.35.0</version>
       <exclusions>
+        <!-- Provided by jackson2-api plugin -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
@@ -183,30 +177,16 @@
       <artifactId>google-oauth-client</artifactId>
       <version>1.34.1</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
         <!-- Provided by core -->
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-cloudresourcemanager</artifactId>
-      <version>v1-rev${cloudresourcemanager.revision}-${google.api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-container</artifactId>
-      <version>v1-rev${container.revision}-${google.api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>snakeyaml-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
@@ -221,6 +201,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>snakeyaml-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
       <version>3.4.3</version>
@@ -230,10 +214,67 @@
       <artifactId>reactor-extra</artifactId>
       <version>3.4.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>display-url-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>google-oauth-plugin</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Required for InjectedTest. Git 4.4.5 for org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -244,6 +285,7 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
@@ -255,92 +297,12 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <show>public</show>
-          <source>8</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>javadoc</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <compilerArgument>-Xlint:all</compilerArgument>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>au.com.acegi</groupId>
-        <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.1.2</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>xml-format</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <includes>pom.xml</includes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>1.1.0</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>pom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <completionGoals>xml-format:xml-format tidy:pom</completionGoals>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.9</version>
-        <configuration>
-          <sourceDirectory>src/main/java</sourceDirectory>
-          <testSourceDirectory>src/test/java</testSourceDirectory>
-          <verbose>true</verbose>
-          <filesNamePattern>.*\.java</filesNamePattern>
-          <skip>false</skip>
-          <skipSortingImports>false</skipSortingImports>
-          <style>google</style>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>format</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <disableXmlReport>true</disableXmlReport>
+          <useFile>false</useFile>
+          <skipITs>${skipITs}</skipITs>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -349,11 +311,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <disableXmlReport>true</disableXmlReport>
-          <useFile>false</useFile>
-          <skipITs>${skipITs}</skipITs>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -367,7 +324,7 @@
         <version>2.7</version>
         <configuration>
           <instrumentation>
-            <excludes/>
+            <excludes />
           </instrumentation>
           <formats>
             <format>html</format>

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/ClusterUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/ClusterUtil.java
@@ -23,58 +23,58 @@ import com.google.common.base.Strings;
 
 /** Utility functions for converting between {@link Cluster}s and their String representations. */
 class ClusterUtil {
-  /**
-   * Given a GKE {@link Cluster} return a String representation containing the name and location.
-   *
-   * @param cluster The {@link Cluster} object to extract values from.
-   * @return A String of the form "name (location)" based on the given cluster's properties.
-   */
-  static String toNameAndLocation(Cluster cluster) {
-    Preconditions.checkNotNull(cluster);
-    return toNameAndLocation(cluster.getName(), cluster.getLocation());
-  }
-
-  /**
-   * Given a name and location for a cluster, return the combined String representation.
-   *
-   * @param name A non-empty cluster name
-   * @param location A non-empty GCP resource location.
-   * @return A String of the form "name (location)".
-   */
-  static String toNameAndLocation(String name, String location) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
-    return String.format("%s (%s)", name, location);
-  }
-
-  /**
-   * Only used for mocking the {@link
-   * com.google.cloud.graphite.platforms.plugin.client.ContainerClient}. Constructs a {@link
-   * Cluster} from the given nameAndLocation value.
-   *
-   * @param nameAndLocation A non-empty String of the form "name (location)"
-   * @return A cluster with the name and location properties from the provided nameAndLocation.
-   */
-  @VisibleForTesting
-  static Cluster fromNameAndLocation(String nameAndLocation) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
-    String[] values = valuesFromNameAndLocation(nameAndLocation);
-    return new Cluster().setName(values[0]).setLocation(values[1]);
-  }
-
-  /**
-   * Extracts the individual values from a combined nameAndLocation String.
-   *
-   * @param nameAndLocation A non-empty String of the form "name (location)"
-   * @return The String array {name, location} from the provided value.
-   */
-  static String[] valuesFromNameAndLocation(String nameAndLocation) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
-    String[] clusters = nameAndLocation.split(" [(]");
-    if (clusters.length != 2) {
-      throw new IllegalArgumentException("nameAndLocation should be of the form 'name (location)'");
+    /**
+     * Given a GKE {@link Cluster} return a String representation containing the name and location.
+     *
+     * @param cluster The {@link Cluster} object to extract values from.
+     * @return A String of the form "name (location)" based on the given cluster's properties.
+     */
+    static String toNameAndLocation(Cluster cluster) {
+        Preconditions.checkNotNull(cluster);
+        return toNameAndLocation(cluster.getName(), cluster.getLocation());
     }
-    clusters[1] = clusters[1].substring(0, clusters[1].length() - 1);
-    return clusters;
-  }
+
+    /**
+     * Given a name and location for a cluster, return the combined String representation.
+     *
+     * @param name A non-empty cluster name
+     * @param location A non-empty GCP resource location.
+     * @return A String of the form "name (location)".
+     */
+    static String toNameAndLocation(String name, String location) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
+        return String.format("%s (%s)", name, location);
+    }
+
+    /**
+     * Only used for mocking the {@link
+     * com.google.cloud.graphite.platforms.plugin.client.ContainerClient}. Constructs a {@link
+     * Cluster} from the given nameAndLocation value.
+     *
+     * @param nameAndLocation A non-empty String of the form "name (location)"
+     * @return A cluster with the name and location properties from the provided nameAndLocation.
+     */
+    @VisibleForTesting
+    static Cluster fromNameAndLocation(String nameAndLocation) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
+        String[] values = valuesFromNameAndLocation(nameAndLocation);
+        return new Cluster().setName(values[0]).setLocation(values[1]);
+    }
+
+    /**
+     * Extracts the individual values from a combined nameAndLocation String.
+     *
+     * @param nameAndLocation A non-empty String of the form "name (location)"
+     * @return The String array {name, location} from the provided value.
+     */
+    static String[] valuesFromNameAndLocation(String nameAndLocation) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(nameAndLocation));
+        String[] clusters = nameAndLocation.split(" [(]");
+        if (clusters.length != 2) {
+            throw new IllegalArgumentException("nameAndLocation should be of the form 'name (location)'");
+        }
+        clusters[1] = clusters[1].substring(0, clusters[1].length() - 1);
+        return clusters;
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubeConfig.java
@@ -30,185 +30,187 @@ import org.yaml.snakeyaml.Yaml;
  * supports a server-side method for this functionality: b/120097899.
  */
 public class KubeConfig {
-  private static final String KUBECONTEXT_FORMAT = "gke_%s_%s_%s";
-  private static final String KUBESERVER_FORMAT = "https://%s";
-  private static final String API_VERSION = "v1";
-  private static final String CONFIG_KIND = "Config";
+    private static final String KUBECONTEXT_FORMAT = "gke_%s_%s_%s";
+    private static final String KUBESERVER_FORMAT = "https://%s";
+    private static final String API_VERSION = "v1";
+    private static final String CONFIG_KIND = "Config";
 
-  private ImmutableList<Object> contexts;
-  private ImmutableList<Object> clusters;
-  private ImmutableList<Object> users;
-  private String currentContext;
+    private ImmutableList<Object> contexts;
+    private ImmutableList<Object> clusters;
+    private ImmutableList<Object> users;
+    private String currentContext;
 
-  private KubeConfig() {}
+    private KubeConfig() {}
 
-  /** @return This config's contexts. */
-  public ImmutableList<Object> getContexts() {
-    return contexts;
-  }
-
-  private void setContexts(ImmutableList<Object> contexts) {
-    this.contexts = Preconditions.checkNotNull(contexts);
-  }
-
-  /** @return This config's clusters. */
-  public ImmutableList<Object> getClusters() {
-    return clusters;
-  }
-
-  private void setClusters(ImmutableList<Object> clusters) {
-    this.clusters = Preconditions.checkNotNull(clusters);
-  }
-
-  /** @return This config's users. */
-  public ImmutableList<Object> getUsers() {
-    return users;
-  }
-
-  private void setUsers(ImmutableList<Object> users) {
-    this.users = Preconditions.checkNotNull(users);
-  }
-
-  /** @return This config's current context. */
-  public String getCurrentContext() {
-    return currentContext;
-  }
-
-  private void setCurrentContext(String currentContext) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
-    this.currentContext = currentContext;
-  }
-
-  /**
-   * Write a Yaml dump of this {@link KubeConfig}'s data to the specified {@link Writer}.
-   * NOTE(craigatgoogle): The logic here is taken directly from the `gcloud containers clutsers
-   * get-credentials` command's implementation: <a
-   * href="https://github.com/google-cloud-sdk/google-cloud-sdk/blob/2cc7b066a0621fe5d78ac9e69157de56a142e126/lib/surface/container/clusters/get_credentials.py#L87">link</a>.
-   *
-   * @return A string containing a Yaml dump of this {@link KubeConfig}.
-   * @throws IOException If an error was encountered while exporting to Yaml.
-   */
-  public String toYaml() throws IOException {
-    return new Yaml()
-        .dumpAsMap(
-            new ImmutableMap.Builder<String, Object>()
-                .put("apiVersion", API_VERSION)
-                .put("kind", CONFIG_KIND)
-                .put("current-context", getCurrentContext())
-                .put("clusters", getClusters())
-                .put("contexts", getContexts())
-                .put("users", getUsers())
-                .build());
-  }
-
-  /** Builder for {@link KubeConfig}. */
-  public static class Builder {
-    private KubeConfig config;
-
-    public Builder() {
-      config = new KubeConfig();
+    /** @return This config's contexts. */
+    public ImmutableList<Object> getContexts() {
+        return contexts;
     }
 
-    public Builder currentContext(String currentContext) {
-      config.setCurrentContext(currentContext);
-      return this;
+    private void setContexts(ImmutableList<Object> contexts) {
+        this.contexts = Preconditions.checkNotNull(contexts);
     }
 
-    public Builder users(ImmutableList<Object> users) {
-      config.setUsers(users);
-      return this;
+    /** @return This config's clusters. */
+    public ImmutableList<Object> getClusters() {
+        return clusters;
     }
 
-    public Builder contexts(ImmutableList<Object> contexts) {
-      config.setContexts(contexts);
-      return this;
+    private void setClusters(ImmutableList<Object> clusters) {
+        this.clusters = Preconditions.checkNotNull(clusters);
     }
 
-    public Builder clusters(ImmutableList<Object> clusters) {
-      config.setClusters(clusters);
-      return this;
+    /** @return This config's users. */
+    public ImmutableList<Object> getUsers() {
+        return users;
     }
 
-    public KubeConfig build() {
-      Preconditions.checkArgument(!Strings.isNullOrEmpty(config.getCurrentContext()));
-      return config;
+    private void setUsers(ImmutableList<Object> users) {
+        this.users = Preconditions.checkNotNull(users);
     }
-  }
 
-  /**
-   * Creates a {@link KubeConfig} from the specified {@link Cluster}.
-   *
-   * @param projectId The ID of the project the cluster resides in.
-   * @param cluster The cluster data will be drawn from.
-   * @param accessToken Access token for GKE API access.
-   * @return A {@link KubeConfig} from the specified {@link Cluster}.
-   */
-  public static KubeConfig fromCluster(String projectId, Cluster cluster, String accessToken) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
-    Preconditions.checkNotNull(cluster);
+    /** @return This config's current context. */
+    public String getCurrentContext() {
+        return currentContext;
+    }
 
-    final String currentContext =
-        contextString(projectId, cluster.getLocation(), cluster.getName());
-    return new KubeConfig.Builder()
-        .currentContext(currentContext)
-        .contexts(ImmutableList.<Object>of(context(currentContext)))
-        .users(ImmutableList.<Object>of(user(currentContext, cluster, accessToken)))
-        .clusters(ImmutableList.<Object>of(cluster(currentContext, cluster)))
-        .build();
-  }
+    private void setCurrentContext(String currentContext) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
+        this.currentContext = currentContext;
+    }
 
-  @VisibleForTesting
-  static String contextString(String project, String location, String cluster) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(project));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    return String.format(KUBECONTEXT_FORMAT, project, location, cluster);
-  }
+    /**
+     * Write a Yaml dump of this {@link KubeConfig}'s data to the specified {@link Writer}.
+     * NOTE(craigatgoogle): The logic here is taken directly from the `gcloud containers clutsers
+     * get-credentials` command's implementation: <a
+     * href="https://github.com/google-cloud-sdk/google-cloud-sdk/blob/2cc7b066a0621fe5d78ac9e69157de56a142e126/lib/surface/container/clusters/get_credentials.py#L87">link</a>.
+     *
+     * @return A string containing a Yaml dump of this {@link KubeConfig}.
+     * @throws IOException If an error was encountered while exporting to Yaml.
+     */
+    public String toYaml() throws IOException {
+        return new Yaml()
+                .dumpAsMap(new ImmutableMap.Builder<String, Object>()
+                        .put("apiVersion", API_VERSION)
+                        .put("kind", CONFIG_KIND)
+                        .put("current-context", getCurrentContext())
+                        .put("clusters", getClusters())
+                        .put("contexts", getContexts())
+                        .put("users", getUsers())
+                        .build());
+    }
 
-  @VisibleForTesting
-  static String clusterServer(Cluster cluster) {
-    Preconditions.checkNotNull(cluster);
-    return String.format(KUBESERVER_FORMAT, cluster.getEndpoint());
-  }
+    /** Builder for {@link KubeConfig}. */
+    public static class Builder {
+        private KubeConfig config;
 
-  private static ImmutableMap<String, Object> context(String currentContext) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
-    return new ImmutableMap.Builder<String, Object>()
-        .put("name", currentContext)
-        .put(
-            "context",
-            new ImmutableMap.Builder<String, Object>()
-                .put("cluster", currentContext)
-                .put("user", currentContext)
-                .put("namespace", "default")
-                .build())
-        .build();
-  }
+        public Builder() {
+            config = new KubeConfig();
+        }
 
-  private static ImmutableMap<String, Object> user(
-      String currentContext, Cluster cluster, String accessToken) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
-    Preconditions.checkNotNull(cluster);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(accessToken));
+        public Builder currentContext(String currentContext) {
+            config.setCurrentContext(currentContext);
+            return this;
+        }
 
-    return new ImmutableMap.Builder<String, Object>()
-        .put("name", currentContext)
-        .put("user", new ImmutableMap.Builder<String, Object>().put("token", accessToken).build())
-        .build();
-  }
+        public Builder users(ImmutableList<Object> users) {
+            config.setUsers(users);
+            return this;
+        }
 
-  private static ImmutableMap<String, Object> cluster(String currentContext, Cluster cluster) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
-    Preconditions.checkNotNull(cluster);
-    return new ImmutableMap.Builder<String, Object>()
-        .put("name", currentContext)
-        .put(
-            "cluster",
-            new ImmutableMap.Builder<String, Object>()
-                .put("server", clusterServer(cluster))
+        public Builder contexts(ImmutableList<Object> contexts) {
+            config.setContexts(contexts);
+            return this;
+        }
+
+        public Builder clusters(ImmutableList<Object> clusters) {
+            config.setClusters(clusters);
+            return this;
+        }
+
+        public KubeConfig build() {
+            Preconditions.checkArgument(!Strings.isNullOrEmpty(config.getCurrentContext()));
+            return config;
+        }
+    }
+
+    /**
+     * Creates a {@link KubeConfig} from the specified {@link Cluster}.
+     *
+     * @param projectId The ID of the project the cluster resides in.
+     * @param cluster The cluster data will be drawn from.
+     * @param accessToken Access token for GKE API access.
+     * @return A {@link KubeConfig} from the specified {@link Cluster}.
+     */
+    public static KubeConfig fromCluster(String projectId, Cluster cluster, String accessToken) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
+        Preconditions.checkNotNull(cluster);
+
+        final String currentContext = contextString(projectId, cluster.getLocation(), cluster.getName());
+        return new KubeConfig.Builder()
+                .currentContext(currentContext)
+                .contexts(ImmutableList.<Object>of(context(currentContext)))
+                .users(ImmutableList.<Object>of(user(currentContext, cluster, accessToken)))
+                .clusters(ImmutableList.<Object>of(cluster(currentContext, cluster)))
+                .build();
+    }
+
+    @VisibleForTesting
+    static String contextString(String project, String location, String cluster) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(project));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
+        return String.format(KUBECONTEXT_FORMAT, project, location, cluster);
+    }
+
+    @VisibleForTesting
+    static String clusterServer(Cluster cluster) {
+        Preconditions.checkNotNull(cluster);
+        return String.format(KUBESERVER_FORMAT, cluster.getEndpoint());
+    }
+
+    private static ImmutableMap<String, Object> context(String currentContext) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
+        return new ImmutableMap.Builder<String, Object>()
+                .put("name", currentContext)
                 .put(
-                    "certificate-authority-data", cluster.getMasterAuth().getClusterCaCertificate())
-                .build())
-        .build();
-  }
+                        "context",
+                        new ImmutableMap.Builder<String, Object>()
+                                .put("cluster", currentContext)
+                                .put("user", currentContext)
+                                .put("namespace", "default")
+                                .build())
+                .build();
+    }
+
+    private static ImmutableMap<String, Object> user(String currentContext, Cluster cluster, String accessToken) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
+        Preconditions.checkNotNull(cluster);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(accessToken));
+
+        return new ImmutableMap.Builder<String, Object>()
+                .put("name", currentContext)
+                .put(
+                        "user",
+                        new ImmutableMap.Builder<String, Object>()
+                                .put("token", accessToken)
+                                .build())
+                .build();
+    }
+
+    private static ImmutableMap<String, Object> cluster(String currentContext, Cluster cluster) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(currentContext));
+        Preconditions.checkNotNull(cluster);
+        return new ImmutableMap.Builder<String, Object>()
+                .put("name", currentContext)
+                .put(
+                        "cluster",
+                        new ImmutableMap.Builder<String, Object>()
+                                .put("server", clusterServer(cluster))
+                                .put(
+                                        "certificate-authority-data",
+                                        cluster.getMasterAuth().getClusterCaCertificate())
+                                .build())
+                .build();
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilder.java
@@ -68,614 +68,605 @@ import org.kohsuke.stapler.QueryParameter;
 
 /** Provides a build step for publishing build artifacts to a Kubernetes cluster running on GKE. */
 public class KubernetesEngineBuilder extends Builder implements SimpleBuildStep, Serializable {
-  public static final long serialVersionUID = 333L;
-  private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilder.class.getName());
-  static final String EMPTY_NAME = "- none -";
-  static final String EMPTY_VALUE = "";
-  static final int DEFAULT_VERIFY_TIMEOUT_MINUTES = 5;
-  static final String METRICS_LABEL_KEY = "app.kubernetes.io/managed-by";
-  static final String METRICS_LABEL_VALUE = "graphite-jenkins-gke";
-  static final ImmutableSet<String> METRICS_TARGET_TYPES =
-      ImmutableSet.of("Deployment", "Service", "ReplicaSet");
+    public static final long serialVersionUID = 333L;
+    private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilder.class.getName());
+    static final String EMPTY_NAME = "- none -";
+    static final String EMPTY_VALUE = "";
+    static final int DEFAULT_VERIFY_TIMEOUT_MINUTES = 5;
+    static final String METRICS_LABEL_KEY = "app.kubernetes.io/managed-by";
+    static final String METRICS_LABEL_VALUE = "graphite-jenkins-gke";
+    static final ImmutableSet<String> METRICS_TARGET_TYPES = ImmutableSet.of("Deployment", "Service", "ReplicaSet");
 
-  private String credentialsId;
-  private String projectId;
-  @Deprecated private String zone;
-  private String location;
-  private String clusterName;
-  private String namespace;
-  private String manifestPattern;
-  private boolean verifyDeployments;
-  private int verifyTimeoutInMinutes = DEFAULT_VERIFY_TIMEOUT_MINUTES;
-  private boolean verifyServices;
-  private boolean isTestCleanup;
-  private boolean verboseLogging = false;
-  private LinkedList<KubeConfigAfterBuildStep> afterBuildStepStack;
-
-  /** Constructs a new {@link KubernetesEngineBuilder}. */
-  @DataBoundConstructor
-  public KubernetesEngineBuilder() {}
-
-  public String getCredentialsId() {
-    return this.credentialsId;
-  }
-
-  @DataBoundSetter
-  public void setCredentialsId(String credentialsId) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
-    this.credentialsId = credentialsId;
-  }
-
-  public String getProjectId() {
-    return this.projectId;
-  }
-
-  @DataBoundSetter
-  public void setProjectId(String projectId) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
-    this.projectId = projectId;
-  }
-
-  @Deprecated
-  public String getZone() {
-    return getLocation();
-  }
-
-  @Deprecated
-  @DataBoundSetter
-  public void setZone(String zone) {
-    setLocation(zone);
-  }
-
-  public String getLocation() {
-    setupLocation();
-    return this.location;
-  }
-
-  @DataBoundSetter
-  public void setLocation(String location) {
-    setupLocation();
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
-    this.location = location;
-  }
-
-  private void setupLocation() {
-    if (Strings.isNullOrEmpty(this.location)) {
-      this.location = this.zone;
-      this.zone = null;
-    }
-  }
-
-  public String getClusterName() {
-    return this.clusterName;
-  }
-
-  @DataBoundSetter
-  public void setClusterName(String clusterName) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(clusterName));
-    this.clusterName = clusterName;
-  }
-
-  public String getCluster() {
-    setupLocation();
-    return ClusterUtil.toNameAndLocation(this.clusterName, this.location);
-  }
-
-  @DataBoundSetter
-  public void setCluster(String cluster) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
-    String[] values = ClusterUtil.valuesFromNameAndLocation(cluster);
-    setClusterName(values[0]);
-    setLocation(values[1]);
-  }
-
-  public String getNamespace() {
-    return this.namespace;
-  }
-
-  @DataBoundSetter
-  public void setNamespace(String namespace) {
-    this.namespace = namespace == null ? "" : namespace;
-  }
-
-  public String getManifestPattern() {
-    return this.manifestPattern;
-  }
-
-  @DataBoundSetter
-  public void setManifestPattern(String manifestPattern) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(manifestPattern));
-    this.manifestPattern = manifestPattern;
-  }
-
-  @DataBoundSetter
-  public void setVerifyDeployments(boolean verifyDeployments) {
-    this.verifyDeployments = verifyDeployments;
-  }
-
-  public boolean isVerifyDeployments() {
-    return this.verifyDeployments;
-  }
-
-  @DataBoundSetter
-  public void setVerifyServices(boolean verifyServices) {
-    this.verifyServices = verifyServices;
-  }
-
-  public boolean isVerifyServices() {
-    return this.verifyServices;
-  }
-
-  public int getVerifyTimeoutInMinutes() {
-    return verifyTimeoutInMinutes;
-  }
-
-  @DataBoundSetter
-  public void setVerifyTimeoutInMinutes(int verifyTimeoutInMinutes) {
-    this.verifyTimeoutInMinutes = verifyTimeoutInMinutes;
-  }
-
-  public boolean isVerboseLogging() {
-    return this.verboseLogging;
-  }
-
-  @DataBoundSetter
-  public void setVerboseLogging(boolean verboseLogging) {
-    this.verboseLogging = verboseLogging;
-  }
-
-  @VisibleForTesting
-  void pushAfterBuildStep(KubeConfigAfterBuildStep afterBuildStep) {
-    if (afterBuildStepStack == null) {
-      afterBuildStepStack = new LinkedList<>();
-    }
-
-    afterBuildStepStack.push(afterBuildStep);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public void perform(
-      @NonNull Run<?, ?> run,
-      @NonNull FilePath workspace,
-      @NonNull Launcher launcher,
-      @NonNull TaskListener listener)
-      throws InterruptedException, IOException {
-    LOGGER.log(
-        Level.INFO,
-        String.format(
-            "GKE Deploying, projectId: %s cluster: %s location: %s",
-            projectId, clusterName, getLocation()));
-    ContainerClient client = getContainerClient(credentialsId);
-    Cluster cluster = client.getCluster(projectId, getLocation(), clusterName);
-
-    // generate a kubeconfig for the cluster
-    KubeConfig kubeConfig =
-        KubeConfig.fromCluster(projectId, cluster, CredentialsUtil.getAccessToken(credentialsId));
-
-    KubectlWrapper kubectl =
-        new KubectlWrapper.Builder()
-            .workspace(workspace)
-            .launcher(launcher)
-            .kubeConfig(kubeConfig)
-            .namespace(namespace)
-            .verboseLogging(verboseLogging)
-            .build();
-
-    FilePath manifestFile = workspace.child(manifestPattern);
-    addMetricsLabel(manifestFile);
-    kubectl.runKubectlCommand("apply", ImmutableList.of("-f", manifestFile.getRemote()));
-    try {
-      if (verifyDeployments && !verify(kubectl, manifestPattern, workspace, listener.getLogger())) {
-        throw new AbortException(Messages.KubernetesEngineBuilder_KubernetesObjectsNotVerified());
-      }
-    } finally {
-      // run the after build step if it exists
-      // NOTE(craigatgoogle): Due to the reflective way this class is created, initializers aren't
-      // run, so we still have to check for null.
-      if (afterBuildStepStack != null) {
-        while (!afterBuildStepStack.isEmpty()) {
-          afterBuildStepStack.pop().perform(kubeConfig, run, workspace, launcher, listener);
-        }
-      }
-    }
-  }
-
-  @Override
-  public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.BUILD;
-  }
-
-  /**
-   * Adds a Kubernetes user label unique to this Jenkins plugin to the specified manifest,
-   * (in-place) in order to enable Jenkins GKE/GCE non-identifying usage metrics. Behavior with
-   * malformed manifests is undefined.
-   *
-   * @param manifestFile The manifest file to be modified.
-   * @throws IOException If an error occurred while reading/writing the manifest file.
-   * @throws InterruptedException If an error occurred while parsing/dumping YAML.
-   */
-  @VisibleForTesting
-  static void addMetricsLabel(FilePath manifestFile) throws InterruptedException, IOException {
-    Manifests manifests = Manifests.fromFile(manifestFile);
-    for (Manifests.ManifestObject manifest :
-        manifests.getObjectManifestsOfKinds(METRICS_TARGET_TYPES)) {
-      manifest.addLabel(METRICS_LABEL_KEY, METRICS_LABEL_VALUE);
-    }
-
-    manifests.write();
-  }
-
-  /**
-   * Verify the application of the supplied {@link Manifests.ManifestObject}'s to the Kubernetes
-   * cluster.
-   *
-   * @param kubectl The {@link KubectlWrapper} for running the queries on the Kubernetes cluster.
-   * @param manifestPattern The manifest pattern for the list of manifest files to use.
-   * @param workspace The {@link FilePath} to the build workspace directory.
-   * @param consoleLogger The {@link PrintStream} for Jenkins console output.
-   * @return If the verification succeeded.
-   * @throws InterruptedException If an error occurred during verification.
-   * @throws IOException If an error occurred during verification.
-   */
-  private boolean verify(
-      KubectlWrapper kubectl, String manifestPattern, FilePath workspace, PrintStream consoleLogger)
-      throws InterruptedException, IOException {
-    LOGGER.log(
-        Level.INFO,
-        String.format(
-            "GKE verifying deployment to, projectId: %s cluster: %s location: %s manifests: %s",
-            projectId, clusterName, getLocation(), workspace.child(manifestPattern)));
-
-    consoleLogger.println(
-        String.format("Verifying manifests: %s", workspace.child(manifestPattern)));
-
-    Manifests manifests = Manifests.fromFile(workspace.child(manifestPattern));
-
-    // Filter by the kinds of manifests being verified.
-    List<Manifests.ManifestObject> manifestObjects =
-        manifests.getObjectManifestsOfKinds(ImmutableSet.of(KubernetesVerifiers.DEPLOYMENT_KIND));
-
-    consoleLogger.println(
-        Messages.KubernetesEngineBuilder_VerifyingNObjects(manifestObjects.size()));
-
-    return VerificationTask.verifyObjects(
-        kubectl, manifestObjects, consoleLogger, verifyTimeoutInMinutes);
-  }
-
-  /**
-   * Ensures the executing user has the permissions to be running this step.
-   *
-   * @throws AccessDeniedException If the user lacks the proper permissions.
-   */
-  private static void checkPermissions() {
-    Jenkins jenkins = Jenkins.getInstanceOrNull();
-    // This check ensures mocks don't break.
-    if (jenkins != null) {
-      jenkins.checkPermission(Job.CONFIGURE);
-    }
-  }
-
-  @Symbol("kubernetesEngineDeploy")
-  @Extension
-  public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    private ClientFactory clientFactory;
-    private String defaultProjectId;
     private String credentialsId;
+    private String projectId;
 
-    @NonNull
-    @Override
-    public String getDisplayName() {
-      return Messages.KubernetesEngineBuilder_DisplayName();
+    @Deprecated
+    private String zone;
+
+    private String location;
+    private String clusterName;
+    private String namespace;
+    private String manifestPattern;
+    private boolean verifyDeployments;
+    private int verifyTimeoutInMinutes = DEFAULT_VERIFY_TIMEOUT_MINUTES;
+    private boolean verifyServices;
+    private boolean isTestCleanup;
+    private boolean verboseLogging = false;
+    private LinkedList<KubeConfigAfterBuildStep> afterBuildStepStack;
+
+    /** Constructs a new {@link KubernetesEngineBuilder}. */
+    @DataBoundConstructor
+    public KubernetesEngineBuilder() {}
+
+    public String getCredentialsId() {
+        return this.credentialsId;
     }
 
-    @Override
-    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-      return true;
-    }
-
-    @VisibleForTesting
-    ClientFactory getClientFactory(Jenkins context, String credentialsId) throws AbortException {
-      if (this.clientFactory == null || updateCredentialsId(credentialsId)) {
-        this.clientFactory = ClientUtil.getClientFactory(context, credentialsId);
-      }
-      return this.clientFactory;
-    }
-
-    @VisibleForTesting
-    String getDefaultProjectId(Jenkins context, String credentialsId) throws AbortException {
-      if (this.defaultProjectId == null || updateCredentialsId(credentialsId)) {
-        this.defaultProjectId = CredentialsUtil.getDefaultProjectId(context, credentialsId);
-      }
-      return this.defaultProjectId;
-    }
-
-    private boolean updateCredentialsId(String credentialsId) {
-      if (this.credentialsId == null || !this.credentialsId.equals(credentialsId)) {
+    @DataBoundSetter
+    public void setCredentialsId(String credentialsId) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
         this.credentialsId = credentialsId;
-        return true;
-      }
-      return false;
     }
 
-    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Jenkins context) {
-      if (context == null || !context.hasPermission(CredentialsProvider.VIEW)) {
-        return new StandardListBoxModel();
-      }
-
-      return new StandardListBoxModel()
-          .includeEmptyValue()
-          .includeMatchingAs(
-              ACL.SYSTEM,
-              context,
-              StandardCredentials.class,
-              Collections.<DomainRequirement>emptyList(),
-              CredentialsMatchers.instanceOf(GoogleOAuth2Credentials.class));
+    public String getProjectId() {
+        return this.projectId;
     }
 
-    public FormValidation doCheckCredentialsId(
-        @AncestorInPath Jenkins context,
-        @QueryParameter("credentialsId") final String credentialsId) {
-      checkPermissions();
-      if (credentialsId.isEmpty()) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_NoCredential());
-      }
-
-      try {
-        CredentialsUtil.getAccessToken(context, credentialsId);
-      } catch (IOException ex) {
-        LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
-        return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
-      }
-
-      return FormValidation.ok();
+    @DataBoundSetter
+    public void setProjectId(String projectId) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(projectId));
+        this.projectId = projectId;
     }
 
-    public ListBoxModel doFillProjectIdItems(
-        @AncestorInPath Jenkins context,
-        @QueryParameter("projectId") final String projectId,
-        @QueryParameter("credentialsId") final String credentialsId) {
-      checkPermissions();
-      ListBoxModel items = new ListBoxModel();
-      items.add(EMPTY_NAME, EMPTY_VALUE);
-      if (Strings.isNullOrEmpty(credentialsId)) {
-        return items;
-      }
+    @Deprecated
+    public String getZone() {
+        return getLocation();
+    }
 
-      ClientFactory clientFactory;
-      String defaultProjectId;
-      try {
-        clientFactory = this.getClientFactory(context, credentialsId);
-        defaultProjectId = getDefaultProjectId(context, credentialsId);
-      } catch (AbortException | RuntimeException ex) {
-        LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
-        items.clear();
-        items.add(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), EMPTY_VALUE);
-        return items;
-      }
+    @Deprecated
+    @DataBoundSetter
+    public void setZone(String zone) {
+        setLocation(zone);
+    }
 
-      try {
-        CloudResourceManagerClient client = clientFactory.cloudResourceManagerClient();
-        List<Project> projects = client.listProjects();
+    public String getLocation() {
+        setupLocation();
+        return this.location;
+    }
 
-        if (projects.isEmpty()) {
-          return items;
+    @DataBoundSetter
+    public void setLocation(String location) {
+        setupLocation();
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(location));
+        this.location = location;
+    }
+
+    private void setupLocation() {
+        if (Strings.isNullOrEmpty(this.location)) {
+            this.location = this.zone;
+            this.zone = null;
+        }
+    }
+
+    public String getClusterName() {
+        return this.clusterName;
+    }
+
+    @DataBoundSetter
+    public void setClusterName(String clusterName) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(clusterName));
+        this.clusterName = clusterName;
+    }
+
+    public String getCluster() {
+        setupLocation();
+        return ClusterUtil.toNameAndLocation(this.clusterName, this.location);
+    }
+
+    @DataBoundSetter
+    public void setCluster(String cluster) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(cluster));
+        String[] values = ClusterUtil.valuesFromNameAndLocation(cluster);
+        setClusterName(values[0]);
+        setLocation(values[1]);
+    }
+
+    public String getNamespace() {
+        return this.namespace;
+    }
+
+    @DataBoundSetter
+    public void setNamespace(String namespace) {
+        this.namespace = namespace == null ? "" : namespace;
+    }
+
+    public String getManifestPattern() {
+        return this.manifestPattern;
+    }
+
+    @DataBoundSetter
+    public void setManifestPattern(String manifestPattern) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(manifestPattern));
+        this.manifestPattern = manifestPattern;
+    }
+
+    @DataBoundSetter
+    public void setVerifyDeployments(boolean verifyDeployments) {
+        this.verifyDeployments = verifyDeployments;
+    }
+
+    public boolean isVerifyDeployments() {
+        return this.verifyDeployments;
+    }
+
+    @DataBoundSetter
+    public void setVerifyServices(boolean verifyServices) {
+        this.verifyServices = verifyServices;
+    }
+
+    public boolean isVerifyServices() {
+        return this.verifyServices;
+    }
+
+    public int getVerifyTimeoutInMinutes() {
+        return verifyTimeoutInMinutes;
+    }
+
+    @DataBoundSetter
+    public void setVerifyTimeoutInMinutes(int verifyTimeoutInMinutes) {
+        this.verifyTimeoutInMinutes = verifyTimeoutInMinutes;
+    }
+
+    public boolean isVerboseLogging() {
+        return this.verboseLogging;
+    }
+
+    @DataBoundSetter
+    public void setVerboseLogging(boolean verboseLogging) {
+        this.verboseLogging = verboseLogging;
+    }
+
+    @VisibleForTesting
+    void pushAfterBuildStep(KubeConfigAfterBuildStep afterBuildStep) {
+        if (afterBuildStepStack == null) {
+            afterBuildStepStack = new LinkedList<>();
         }
 
-        projects.stream()
-            .filter(p -> !p.getProjectId().equals(defaultProjectId))
-            .forEach(p -> items.add(p.getProjectId()));
-
-        if (Strings.isNullOrEmpty(defaultProjectId)) {
-          selectOption(items, projectId);
-          return items;
-        }
-
-        if (projects.size() == items.size() && Strings.isNullOrEmpty(projectId)) {
-          items.add(new Option(defaultProjectId, defaultProjectId, true));
-        } else {
-          // Add defaultProjectId anyway, but select the appropriate projectID based on
-          // the previously entered projectID
-          items.add(defaultProjectId);
-          selectOption(items, projectId);
-        }
-        return items;
-      } catch (IOException ioe) {
-        LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ProjectIDFillError(), ioe);
-        items.clear();
-        items.add(Messages.KubernetesEngineBuilder_ProjectIDFillError(), EMPTY_VALUE);
-        return items;
-      }
+        afterBuildStepStack.push(afterBuildStep);
     }
 
-    public FormValidation doCheckProjectId(
-        @AncestorInPath Jenkins context,
-        @QueryParameter("projectId") final String projectId,
-        @QueryParameter("credentialsId") final String credentialsId) {
-      checkPermissions();
-      if (Strings.isNullOrEmpty(credentialsId) && Strings.isNullOrEmpty(projectId)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDRequired());
-      } else if (Strings.isNullOrEmpty(credentialsId)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectCredentialIDRequired());
-      }
-
-      ClientFactory clientFactory;
-      try {
-        clientFactory = getClientFactory(context, credentialsId);
-      } catch (AbortException | RuntimeException e) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
-      }
-
-      try {
-        CloudResourceManagerClient client = clientFactory.cloudResourceManagerClient();
-        List<Project> projects = client.listProjects();
-        if (Strings.isNullOrEmpty(projectId)) {
-          return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDRequired());
-        }
-
-        Optional<Project> matchingProject =
-            projects.stream().filter(p -> projectId.equals(p.getProjectId())).findFirst();
-        if (!matchingProject.isPresent()) {
-          return FormValidation.error(
-              Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential());
-        }
-      } catch (IOException ioe) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDVerificationError());
-      }
-
-      return FormValidation.ok();
-    }
-
-    public ListBoxModel doFillClusterItems(
-        @AncestorInPath Jenkins context,
-        @QueryParameter("cluster") final String cluster,
-        @QueryParameter("credentialsId") final String credentialsId,
-        @QueryParameter("projectId") final String projectId) {
-      checkPermissions();
-      ListBoxModel items = new ListBoxModel();
-      items.add(EMPTY_NAME, EMPTY_VALUE);
-      if (Strings.isNullOrEmpty(credentialsId) || Strings.isNullOrEmpty(projectId)) {
-        return items;
-      }
-
-      ClientFactory clientFactory;
-      try {
-        clientFactory = getClientFactory(context, credentialsId);
-      } catch (AbortException | RuntimeException ex) {
-        LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
-        items.clear();
-        items.add(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), EMPTY_VALUE);
-        return items;
-      }
-
-      try {
-        ContainerClient client = clientFactory.containerClient();
-        List<Cluster> clusters = client.listAllClusters(projectId);
-
-        if (clusters.isEmpty()) {
-          return items;
-        }
-
-        clusters.forEach(c -> items.add(ClusterUtil.toNameAndLocation(c)));
-        selectOption(items, cluster);
-        return items;
-      } catch (IOException ioe) {
-        LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ClusterFillError(), ioe);
-        items.clear();
-        items.add(Messages.KubernetesEngineBuilder_ClusterFillError(), EMPTY_VALUE);
-        return items;
-      }
-    }
-
-    public FormValidation doCheckCluster(
-        @AncestorInPath Jenkins context,
-        @QueryParameter("cluster") final String cluster,
-        @QueryParameter("credentialsId") final String credentialsId,
-        @QueryParameter("projectId") final String projectId) {
-      checkPermissions();
-      if (Strings.isNullOrEmpty(credentialsId) && Strings.isNullOrEmpty(cluster)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
-      } else if (Strings.isNullOrEmpty(credentialsId)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterCredentialIDRequired());
-      }
-
-      ClientFactory clientFactory;
-      try {
-        clientFactory = getClientFactory(context, credentialsId);
-      } catch (AbortException | RuntimeException ex) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
-      }
-
-      if (Strings.isNullOrEmpty(projectId) && Strings.isNullOrEmpty(cluster)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
-      } else if (Strings.isNullOrEmpty(projectId)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterProjectIDRequired());
-      }
-
-      try {
-        ContainerClient client = clientFactory.containerClient();
-        List<Cluster> clusters = client.listAllClusters(projectId);
-        if (Strings.isNullOrEmpty(cluster)) {
-          return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
-        } else if (clusters.size() == 0) {
-          return FormValidation.error(Messages.KubernetesEngineBuilder_NoClusterInProject());
-        }
-        Optional<Cluster> clusterOption =
-            clusters.stream()
-                .filter(c -> cluster.equals(ClusterUtil.toNameAndLocation(c)))
-                .findFirst();
-        if (!clusterOption.isPresent()) {
-          return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterNotInProject());
-        }
-      } catch (IOException ioe) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterVerificationError());
-      }
-      return FormValidation.ok();
-    }
-
-    public FormValidation doCheckNamespace(@QueryParameter("namespace") final String namespace) {
-      checkPermissions();
-      /* Regex from
-       * https://github.com/kubernetes/apimachinery/blob/7d08eb7a76fdbc79f7bc1b5fb061ae44f3324bfa/pkg/util/validation/validation.go#L110
-       */
-      if (!Strings.isNullOrEmpty(namespace)
-          && !namespace.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?")) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_NamespaceInvalid());
-      }
-      return FormValidation.ok();
-    }
-
-    public FormValidation doCheckManifestPattern(
-        @QueryParameter("manifestPattern") final String manifestPattern) {
-      checkPermissions();
-      if (Strings.isNullOrEmpty(manifestPattern)) {
-        return FormValidation.error(Messages.KubernetesEngineBuilder_ManifestRequired());
-      }
-      return FormValidation.ok();
-    }
-
-    public FormValidation doCheckVerifyTimeoutInMinutes(
-        @QueryParameter("verifyTimeoutInMinutes") final String verifyTimeoutInMinutes) {
-      checkPermissions();
-      if (Strings.isNullOrEmpty(verifyTimeoutInMinutes)) {
-        return FormValidation.error(
-            Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesRequired());
-      }
-
-      if (!verifyTimeoutInMinutes.matches("([1-9]\\d*)")) {
-        return FormValidation.error(
-            Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError());
-      }
-
-      return FormValidation.ok();
-    }
-  }
-
-  private static void selectOption(ListBoxModel listBoxModel, String optionValue) {
-    Optional<Option> item;
-    if (!Strings.isNullOrEmpty(optionValue)) {
-      item = listBoxModel.stream().filter(option -> optionValue.equals(option.value)).findFirst();
-      if (item.isPresent()) {
-        item.get().selected = true;
-        return;
-      }
-    }
-    item = listBoxModel.stream().filter(option -> !Strings.isNullOrEmpty(option.value)).findFirst();
-    item.ifPresent(i -> i.selected = true);
-  }
-
-  private static ContainerClient getContainerClient(String credentialsId) throws AbortException {
-    return ClientUtil.getClientFactory(Jenkins.get(), credentialsId).containerClient();
-  }
-
-  @FunctionalInterface
-  interface KubeConfigAfterBuildStep extends Serializable {
+    /** {@inheritDoc} */
+    @Override
     public void perform(
-        KubeConfig kubeConfig,
-        Run<?, ?> run,
-        FilePath workspace,
-        Launcher launcher,
-        TaskListener listener)
-        throws AbortException, InterruptedException, IOException;
-  }
+            @NonNull Run<?, ?> run,
+            @NonNull FilePath workspace,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener)
+            throws InterruptedException, IOException {
+        LOGGER.log(
+                Level.INFO,
+                String.format(
+                        "GKE Deploying, projectId: %s cluster: %s location: %s",
+                        projectId, clusterName, getLocation()));
+        ContainerClient client = getContainerClient(credentialsId);
+        Cluster cluster = client.getCluster(projectId, getLocation(), clusterName);
+
+        // generate a kubeconfig for the cluster
+        KubeConfig kubeConfig =
+                KubeConfig.fromCluster(projectId, cluster, CredentialsUtil.getAccessToken(credentialsId));
+
+        KubectlWrapper kubectl = new KubectlWrapper.Builder()
+                .workspace(workspace)
+                .launcher(launcher)
+                .kubeConfig(kubeConfig)
+                .namespace(namespace)
+                .verboseLogging(verboseLogging)
+                .build();
+
+        FilePath manifestFile = workspace.child(manifestPattern);
+        addMetricsLabel(manifestFile);
+        kubectl.runKubectlCommand("apply", ImmutableList.of("-f", manifestFile.getRemote()));
+        try {
+            if (verifyDeployments && !verify(kubectl, manifestPattern, workspace, listener.getLogger())) {
+                throw new AbortException(Messages.KubernetesEngineBuilder_KubernetesObjectsNotVerified());
+            }
+        } finally {
+            // run the after build step if it exists
+            // NOTE(craigatgoogle): Due to the reflective way this class is created, initializers aren't
+            // run, so we still have to check for null.
+            if (afterBuildStepStack != null) {
+                while (!afterBuildStepStack.isEmpty()) {
+                    afterBuildStepStack.pop().perform(kubeConfig, run, workspace, launcher, listener);
+                }
+            }
+        }
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
+
+    /**
+     * Adds a Kubernetes user label unique to this Jenkins plugin to the specified manifest,
+     * (in-place) in order to enable Jenkins GKE/GCE non-identifying usage metrics. Behavior with
+     * malformed manifests is undefined.
+     *
+     * @param manifestFile The manifest file to be modified.
+     * @throws IOException If an error occurred while reading/writing the manifest file.
+     * @throws InterruptedException If an error occurred while parsing/dumping YAML.
+     */
+    @VisibleForTesting
+    static void addMetricsLabel(FilePath manifestFile) throws InterruptedException, IOException {
+        Manifests manifests = Manifests.fromFile(manifestFile);
+        for (Manifests.ManifestObject manifest : manifests.getObjectManifestsOfKinds(METRICS_TARGET_TYPES)) {
+            manifest.addLabel(METRICS_LABEL_KEY, METRICS_LABEL_VALUE);
+        }
+
+        manifests.write();
+    }
+
+    /**
+     * Verify the application of the supplied {@link Manifests.ManifestObject}'s to the Kubernetes
+     * cluster.
+     *
+     * @param kubectl The {@link KubectlWrapper} for running the queries on the Kubernetes cluster.
+     * @param manifestPattern The manifest pattern for the list of manifest files to use.
+     * @param workspace The {@link FilePath} to the build workspace directory.
+     * @param consoleLogger The {@link PrintStream} for Jenkins console output.
+     * @return If the verification succeeded.
+     * @throws InterruptedException If an error occurred during verification.
+     * @throws IOException If an error occurred during verification.
+     */
+    private boolean verify(
+            KubectlWrapper kubectl, String manifestPattern, FilePath workspace, PrintStream consoleLogger)
+            throws InterruptedException, IOException {
+        LOGGER.log(
+                Level.INFO,
+                String.format(
+                        "GKE verifying deployment to, projectId: %s cluster: %s location: %s manifests: %s",
+                        projectId, clusterName, getLocation(), workspace.child(manifestPattern)));
+
+        consoleLogger.println(String.format("Verifying manifests: %s", workspace.child(manifestPattern)));
+
+        Manifests manifests = Manifests.fromFile(workspace.child(manifestPattern));
+
+        // Filter by the kinds of manifests being verified.
+        List<Manifests.ManifestObject> manifestObjects =
+                manifests.getObjectManifestsOfKinds(ImmutableSet.of(KubernetesVerifiers.DEPLOYMENT_KIND));
+
+        consoleLogger.println(Messages.KubernetesEngineBuilder_VerifyingNObjects(manifestObjects.size()));
+
+        return VerificationTask.verifyObjects(kubectl, manifestObjects, consoleLogger, verifyTimeoutInMinutes);
+    }
+
+    /**
+     * Ensures the executing user has the permissions to be running this step.
+     *
+     * @throws AccessDeniedException If the user lacks the proper permissions.
+     */
+    private static void checkPermissions() {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        // This check ensures mocks don't break.
+        if (jenkins != null) {
+            jenkins.checkPermission(Job.CONFIGURE);
+        }
+    }
+
+    @Symbol("kubernetesEngineDeploy")
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        private ClientFactory clientFactory;
+        private String defaultProjectId;
+        private String credentialsId;
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return Messages.KubernetesEngineBuilder_DisplayName();
+        }
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @VisibleForTesting
+        ClientFactory getClientFactory(Jenkins context, String credentialsId) throws AbortException {
+            if (this.clientFactory == null || updateCredentialsId(credentialsId)) {
+                this.clientFactory = ClientUtil.getClientFactory(context, credentialsId);
+            }
+            return this.clientFactory;
+        }
+
+        @VisibleForTesting
+        String getDefaultProjectId(Jenkins context, String credentialsId) throws AbortException {
+            if (this.defaultProjectId == null || updateCredentialsId(credentialsId)) {
+                this.defaultProjectId = CredentialsUtil.getDefaultProjectId(context, credentialsId);
+            }
+            return this.defaultProjectId;
+        }
+
+        private boolean updateCredentialsId(String credentialsId) {
+            if (this.credentialsId == null || !this.credentialsId.equals(credentialsId)) {
+                this.credentialsId = credentialsId;
+                return true;
+            }
+            return false;
+        }
+
+        public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Jenkins context) {
+            if (context == null || !context.hasPermission(CredentialsProvider.VIEW)) {
+                return new StandardListBoxModel();
+            }
+
+            return new StandardListBoxModel()
+                    .includeEmptyValue()
+                    .includeMatchingAs(
+                            ACL.SYSTEM,
+                            context,
+                            StandardCredentials.class,
+                            Collections.<DomainRequirement>emptyList(),
+                            CredentialsMatchers.instanceOf(GoogleOAuth2Credentials.class));
+        }
+
+        public FormValidation doCheckCredentialsId(
+                @AncestorInPath Jenkins context, @QueryParameter("credentialsId") final String credentialsId) {
+            checkPermissions();
+            if (credentialsId.isEmpty()) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_NoCredential());
+            }
+
+            try {
+                CredentialsUtil.getAccessToken(context, credentialsId);
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
+                return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
+            }
+
+            return FormValidation.ok();
+        }
+
+        public ListBoxModel doFillProjectIdItems(
+                @AncestorInPath Jenkins context,
+                @QueryParameter("projectId") final String projectId,
+                @QueryParameter("credentialsId") final String credentialsId) {
+            checkPermissions();
+            ListBoxModel items = new ListBoxModel();
+            items.add(EMPTY_NAME, EMPTY_VALUE);
+            if (Strings.isNullOrEmpty(credentialsId)) {
+                return items;
+            }
+
+            ClientFactory clientFactory;
+            String defaultProjectId;
+            try {
+                clientFactory = this.getClientFactory(context, credentialsId);
+                defaultProjectId = getDefaultProjectId(context, credentialsId);
+            } catch (AbortException | RuntimeException ex) {
+                LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
+                items.clear();
+                items.add(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), EMPTY_VALUE);
+                return items;
+            }
+
+            try {
+                CloudResourceManagerClient client = clientFactory.cloudResourceManagerClient();
+                List<Project> projects = client.listProjects();
+
+                if (projects.isEmpty()) {
+                    return items;
+                }
+
+                projects.stream()
+                        .filter(p -> !p.getProjectId().equals(defaultProjectId))
+                        .forEach(p -> items.add(p.getProjectId()));
+
+                if (Strings.isNullOrEmpty(defaultProjectId)) {
+                    selectOption(items, projectId);
+                    return items;
+                }
+
+                if (projects.size() == items.size() && Strings.isNullOrEmpty(projectId)) {
+                    items.add(new Option(defaultProjectId, defaultProjectId, true));
+                } else {
+                    // Add defaultProjectId anyway, but select the appropriate projectID based on
+                    // the previously entered projectID
+                    items.add(defaultProjectId);
+                    selectOption(items, projectId);
+                }
+                return items;
+            } catch (IOException ioe) {
+                LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ProjectIDFillError(), ioe);
+                items.clear();
+                items.add(Messages.KubernetesEngineBuilder_ProjectIDFillError(), EMPTY_VALUE);
+                return items;
+            }
+        }
+
+        public FormValidation doCheckProjectId(
+                @AncestorInPath Jenkins context,
+                @QueryParameter("projectId") final String projectId,
+                @QueryParameter("credentialsId") final String credentialsId) {
+            checkPermissions();
+            if (Strings.isNullOrEmpty(credentialsId) && Strings.isNullOrEmpty(projectId)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDRequired());
+            } else if (Strings.isNullOrEmpty(credentialsId)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectCredentialIDRequired());
+            }
+
+            ClientFactory clientFactory;
+            try {
+                clientFactory = getClientFactory(context, credentialsId);
+            } catch (AbortException | RuntimeException e) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
+            }
+
+            try {
+                CloudResourceManagerClient client = clientFactory.cloudResourceManagerClient();
+                List<Project> projects = client.listProjects();
+                if (Strings.isNullOrEmpty(projectId)) {
+                    return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDRequired());
+                }
+
+                Optional<Project> matchingProject = projects.stream()
+                        .filter(p -> projectId.equals(p.getProjectId()))
+                        .findFirst();
+                if (!matchingProject.isPresent()) {
+                    return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential());
+                }
+            } catch (IOException ioe) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ProjectIDVerificationError());
+            }
+
+            return FormValidation.ok();
+        }
+
+        public ListBoxModel doFillClusterItems(
+                @AncestorInPath Jenkins context,
+                @QueryParameter("cluster") final String cluster,
+                @QueryParameter("credentialsId") final String credentialsId,
+                @QueryParameter("projectId") final String projectId) {
+            checkPermissions();
+            ListBoxModel items = new ListBoxModel();
+            items.add(EMPTY_NAME, EMPTY_VALUE);
+            if (Strings.isNullOrEmpty(credentialsId) || Strings.isNullOrEmpty(projectId)) {
+                return items;
+            }
+
+            ClientFactory clientFactory;
+            try {
+                clientFactory = getClientFactory(context, credentialsId);
+            } catch (AbortException | RuntimeException ex) {
+                LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_CredentialAuthFailed(), ex);
+                items.clear();
+                items.add(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), EMPTY_VALUE);
+                return items;
+            }
+
+            try {
+                ContainerClient client = clientFactory.containerClient();
+                List<Cluster> clusters = client.listAllClusters(projectId);
+
+                if (clusters.isEmpty()) {
+                    return items;
+                }
+
+                clusters.forEach(c -> items.add(ClusterUtil.toNameAndLocation(c)));
+                selectOption(items, cluster);
+                return items;
+            } catch (IOException ioe) {
+                LOGGER.log(Level.SEVERE, Messages.KubernetesEngineBuilder_ClusterFillError(), ioe);
+                items.clear();
+                items.add(Messages.KubernetesEngineBuilder_ClusterFillError(), EMPTY_VALUE);
+                return items;
+            }
+        }
+
+        public FormValidation doCheckCluster(
+                @AncestorInPath Jenkins context,
+                @QueryParameter("cluster") final String cluster,
+                @QueryParameter("credentialsId") final String credentialsId,
+                @QueryParameter("projectId") final String projectId) {
+            checkPermissions();
+            if (Strings.isNullOrEmpty(credentialsId) && Strings.isNullOrEmpty(cluster)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
+            } else if (Strings.isNullOrEmpty(credentialsId)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterCredentialIDRequired());
+            }
+
+            ClientFactory clientFactory;
+            try {
+                clientFactory = getClientFactory(context, credentialsId);
+            } catch (AbortException | RuntimeException ex) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_CredentialAuthFailed());
+            }
+
+            if (Strings.isNullOrEmpty(projectId) && Strings.isNullOrEmpty(cluster)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
+            } else if (Strings.isNullOrEmpty(projectId)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterProjectIDRequired());
+            }
+
+            try {
+                ContainerClient client = clientFactory.containerClient();
+                List<Cluster> clusters = client.listAllClusters(projectId);
+                if (Strings.isNullOrEmpty(cluster)) {
+                    return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterRequired());
+                } else if (clusters.size() == 0) {
+                    return FormValidation.error(Messages.KubernetesEngineBuilder_NoClusterInProject());
+                }
+                Optional<Cluster> clusterOption = clusters.stream()
+                        .filter(c -> cluster.equals(ClusterUtil.toNameAndLocation(c)))
+                        .findFirst();
+                if (!clusterOption.isPresent()) {
+                    return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterNotInProject());
+                }
+            } catch (IOException ioe) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ClusterVerificationError());
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckNamespace(@QueryParameter("namespace") final String namespace) {
+            checkPermissions();
+            /* Regex from
+             * https://github.com/kubernetes/apimachinery/blob/7d08eb7a76fdbc79f7bc1b5fb061ae44f3324bfa/pkg/util/validation/validation.go#L110
+             */
+            if (!Strings.isNullOrEmpty(namespace) && !namespace.matches("[a-z0-9]([-a-z0-9]*[a-z0-9])?")) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_NamespaceInvalid());
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckManifestPattern(@QueryParameter("manifestPattern") final String manifestPattern) {
+            checkPermissions();
+            if (Strings.isNullOrEmpty(manifestPattern)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_ManifestRequired());
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckVerifyTimeoutInMinutes(
+                @QueryParameter("verifyTimeoutInMinutes") final String verifyTimeoutInMinutes) {
+            checkPermissions();
+            if (Strings.isNullOrEmpty(verifyTimeoutInMinutes)) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesRequired());
+            }
+
+            if (!verifyTimeoutInMinutes.matches("([1-9]\\d*)")) {
+                return FormValidation.error(Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError());
+            }
+
+            return FormValidation.ok();
+        }
+    }
+
+    private static void selectOption(ListBoxModel listBoxModel, String optionValue) {
+        Optional<Option> item;
+        if (!Strings.isNullOrEmpty(optionValue)) {
+            item = listBoxModel.stream()
+                    .filter(option -> optionValue.equals(option.value))
+                    .findFirst();
+            if (item.isPresent()) {
+                item.get().selected = true;
+                return;
+            }
+        }
+        item = listBoxModel.stream()
+                .filter(option -> !Strings.isNullOrEmpty(option.value))
+                .findFirst();
+        item.ifPresent(i -> i.selected = true);
+    }
+
+    private static ContainerClient getContainerClient(String credentialsId) throws AbortException {
+        return ClientUtil.getClientFactory(Jenkins.get(), credentialsId).containerClient();
+    }
+
+    @FunctionalInterface
+    interface KubeConfigAfterBuildStep extends Serializable {
+        public void perform(
+                KubeConfig kubeConfig, Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+                throws AbortException, InterruptedException, IOException;
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiers.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiers.java
@@ -28,209 +28,206 @@ import java.util.logging.Logger;
  * registry of Verifiers per Kubernetes API Kind and Version.
  */
 public class KubernetesVerifiers {
-  private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilder.class.getName());
-  private static Map<String, Verifier> verifiers = new HashMap<String, Verifier>();
-  private static final Verifier defaultVerifier = new DefaultVerifier();
-  public static final String DEPLOYMENT_KIND = "deployment";
-  // Register the available verifiers.
-  static {
-    verifiers.put("*/deployment", new DeploymentVerifier());
-  }
-
-  /**
-   * Represents the result object for verification action. The status field represents whether the
-   * verification succeeded. The toString() returns relevant information pertaining to why the
-   * status is what it is.
-   */
-  public static class VerificationResult {
-    private String log;
-    private boolean status;
-    private Manifests.ManifestObject manifestObject;
-
-    /** @return Information relevant to the result and why the status is what it is. */
-    private String getLog() {
-      return log;
-    }
-
-    /** @return If the Kubernetes object was verified. */
-    public boolean isVerified() {
-      return status;
-    }
-
-    /** @return The {@link Manifests.ManifestObject} for which verification was attempted. */
-    public Manifests.ManifestObject getManifestObject() {
-      return manifestObject;
+    private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilder.class.getName());
+    private static Map<String, Verifier> verifiers = new HashMap<String, Verifier>();
+    private static final Verifier defaultVerifier = new DefaultVerifier();
+    public static final String DEPLOYMENT_KIND = "deployment";
+    // Register the available verifiers.
+    static {
+        verifiers.put("*/deployment", new DeploymentVerifier());
     }
 
     /**
-     * Constructs a new {@link VerificationResult}.
-     *
-     * @param log Information relevant to why the status is what it is.
-     * @param status The status of this verification.
-     * @param object The {@link Manifests.ManifestObject} for which this verification was attempted.
+     * Represents the result object for verification action. The status field represents whether the
+     * verification succeeded. The toString() returns relevant information pertaining to why the
+     * status is what it is.
      */
-    public VerificationResult(String log, boolean status, Manifests.ManifestObject object) {
-      this.log = log;
-      this.status = status;
-      this.manifestObject = object;
+    public static class VerificationResult {
+        private String log;
+        private boolean status;
+        private Manifests.ManifestObject manifestObject;
+
+        /** @return Information relevant to the result and why the status is what it is. */
+        private String getLog() {
+            return log;
+        }
+
+        /** @return If the Kubernetes object was verified. */
+        public boolean isVerified() {
+            return status;
+        }
+
+        /** @return The {@link Manifests.ManifestObject} for which verification was attempted. */
+        public Manifests.ManifestObject getManifestObject() {
+            return manifestObject;
+        }
+
+        /**
+         * Constructs a new {@link VerificationResult}.
+         *
+         * @param log Information relevant to why the status is what it is.
+         * @param status The status of this verification.
+         * @param object The {@link Manifests.ManifestObject} for which this verification was attempted.
+         */
+        public VerificationResult(String log, boolean status, Manifests.ManifestObject object) {
+            this.log = log;
+            this.status = status;
+            this.manifestObject = object;
+        }
+
+        /**
+         * Get text description of the result.
+         *
+         * @return Description of the result including whether it was successful (i8n) and the log
+         *     pertaining to why.
+         */
+        public String toString() {
+            return new StringBuilder()
+                    .append(
+                            (status)
+                                    ? Messages.KubernetesEngineBuilder_VerifyingLogSuccess(manifestObject.describe())
+                                    : Messages.KubernetesEngineBuilder_VerifyingLogFailure(manifestObject.describe()))
+                    .append("\n")
+                    .append(log)
+                    .toString();
+        }
     }
 
     /**
-     * Get text description of the result.
-     *
-     * @return Description of the result including whether it was successful (i8n) and the log
-     *     pertaining to why.
+     * A verifier is an adapter that uses a {@link KubectlWrapper} to verify that a {@link
+     * Manifests.ManifestObject} was successfully applied to the Kubernetes cluster.
      */
-    public String toString() {
-      return new StringBuilder()
-          .append(
-              (status)
-                  ? Messages.KubernetesEngineBuilder_VerifyingLogSuccess(manifestObject.describe())
-                  : Messages.KubernetesEngineBuilder_VerifyingLogFailure(manifestObject.describe()))
-          .append("\n")
-          .append(log)
-          .toString();
+    public interface Verifier {
+        /**
+         * Verify the Kubernetes object represented by the {@link Manifests.ManifestObject} was applied
+         * to the Kubernetes cluster.
+         *
+         * @param kubectl A {@link KubectlWrapper} object for querying the object type in the cluster.
+         * @param object The manifest to be verified.
+         * @return true If the resource was verified, false otherwise.
+         */
+        VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object);
     }
-  }
-
-  /**
-   * A verifier is an adapter that uses a {@link KubectlWrapper} to verify that a {@link
-   * Manifests.ManifestObject} was successfully applied to the Kubernetes cluster.
-   */
-  public interface Verifier {
-    /**
-     * Verify the Kubernetes object represented by the {@link Manifests.ManifestObject} was applied
-     * to the Kubernetes cluster.
-     *
-     * @param kubectl A {@link KubectlWrapper} object for querying the object type in the cluster.
-     * @param object The manifest to be verified.
-     * @return true If the resource was verified, false otherwise.
-     */
-    VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object);
-  }
-
-  /**
-   * DefaultVerifier is a fallback verifier for types of objects that are not in the registry. It
-   * fails verification and reports that a verify for the type of object is not implemented. This
-   * verifier shouldn't be used in production.
-   */
-  private static class DefaultVerifier implements Verifier {
 
     /**
-     * Default verifier returns false for unimplemented verifiers.
-     *
-     * @param kubectl A KubectlWrapper object for querying the object type in the cluster.
-     * @param object The Kubernetes object to verify represented by the {@link
-     *     Manifests.ManifestObject}
-     * @return false The unimplemented Verifier case.
+     * DefaultVerifier is a fallback verifier for types of objects that are not in the registry. It
+     * fails verification and reports that a verify for the type of object is not implemented. This
+     * verifier shouldn't be used in production.
      */
-    public VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
-      LOGGER.info("Reached unimplemented default verifier.");
-      return new VerificationResult(
-          Messages.KubernetesEngineBuilder_VerifierNotImplementedFor(object.describe()),
-          false,
-          object);
-    }
-  }
+    private static class DefaultVerifier implements Verifier {
 
-  /**
-   * A {@link Verifier} that verifies a "deployment" object. For a deployment object to be verified
-   * it must have it's minimum number of replicas (spec.replicas) less than or equal to it's
-   * available replicas (status.availableReplicas).
-   */
-  private static class DeploymentVerifier implements Verifier {
-    private static final String AVAILABLE_REPLICAS = "availableReplicas";
-    private static final String MINIMUM_REPLICAS_JSONPATH = "spec.replicas";
-    private static final String STATUS_JSONPATH = "status";
+        /**
+         * Default verifier returns false for unimplemented verifiers.
+         *
+         * @param kubectl A KubectlWrapper object for querying the object type in the cluster.
+         * @param object The Kubernetes object to verify represented by the {@link
+         *     Manifests.ManifestObject}
+         * @return false The unimplemented Verifier case.
+         */
+        public VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
+            LOGGER.info("Reached unimplemented default verifier.");
+            return new VerificationResult(
+                    Messages.KubernetesEngineBuilder_VerifierNotImplementedFor(object.describe()), false, object);
+        }
+    }
 
     /**
-     * Verifies that the deployment was applied to the GKE cluster.
-     *
-     * @param kubectl A {@link KubectlWrapper} object for querying the object type in the cluster.
-     * @param object The deployment {@link Manifests.ManifestObject} that is being verified.
-     * @return true If the minimum number of replicas is less than or equal to the available
-     *     replicas.
+     * A {@link Verifier} that verifies a "deployment" object. For a deployment object to be verified
+     * it must have it's minimum number of replicas (spec.replicas) less than or equal to it's
+     * available replicas (status.availableReplicas).
      */
-    public VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
-      Preconditions.checkArgument(object.getName().isPresent());
-      String name = object.getName().get();
-      LOGGER.info(String.format("Verifying deployment, %s", name));
-      StringBuilder log = new StringBuilder();
-      Object json = null;
+    private static class DeploymentVerifier implements Verifier {
+        private static final String AVAILABLE_REPLICAS = "availableReplicas";
+        private static final String MINIMUM_REPLICAS_JSONPATH = "spec.replicas";
+        private static final String STATUS_JSONPATH = "status";
 
-      try {
-        json = kubectl.getObject(object.getKind().toLowerCase(), name);
-      } catch (Exception e) {
-        return errorResult(e, object);
-      }
+        /**
+         * Verifies that the deployment was applied to the GKE cluster.
+         *
+         * @param kubectl A {@link KubectlWrapper} object for querying the object type in the cluster.
+         * @param object The deployment {@link Manifests.ManifestObject} that is being verified.
+         * @return true If the minimum number of replicas is less than or equal to the available
+         *     replicas.
+         */
+        public VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
+            Preconditions.checkArgument(object.getName().isPresent());
+            String name = object.getName().get();
+            LOGGER.info(String.format("Verifying deployment, %s", name));
+            StringBuilder log = new StringBuilder();
+            Object json = null;
 
-      Integer minReplicas = JsonPath.read(json, MINIMUM_REPLICAS_JSONPATH);
-      Map<String, Object> status = JsonPath.read(json, STATUS_JSONPATH);
-      Integer availableReplicas = (Integer) status.getOrDefault(AVAILABLE_REPLICAS, 0);
-      boolean verified =
-          minReplicas != null
-              && availableReplicas != null
-              && minReplicas.intValue() <= availableReplicas.intValue();
+            try {
+                json = kubectl.getObject(object.getKind().toLowerCase(), name);
+            } catch (Exception e) {
+                return errorResult(e, object);
+            }
 
-      log.append("AvailableReplicas = ")
-          .append(availableReplicas)
-          .append(",")
-          .append(" MinimumReplicas = ")
-          .append(minReplicas)
-          .append("\n");
+            Integer minReplicas = JsonPath.read(json, MINIMUM_REPLICAS_JSONPATH);
+            Map<String, Object> status = JsonPath.read(json, STATUS_JSONPATH);
+            Integer availableReplicas = (Integer) status.getOrDefault(AVAILABLE_REPLICAS, 0);
+            boolean verified = minReplicas != null
+                    && availableReplicas != null
+                    && minReplicas.intValue() <= availableReplicas.intValue();
 
-      return new VerificationResult(log.toString(), verified, object);
+            log.append("AvailableReplicas = ")
+                    .append(availableReplicas)
+                    .append(",")
+                    .append(" MinimumReplicas = ")
+                    .append(minReplicas)
+                    .append("\n");
+
+            return new VerificationResult(log.toString(), verified, object);
+        }
     }
-  }
 
-  /**
-   * Gets the default verifier for an object kind.
-   *
-   * @param kind The object Kind for the verifier.
-   * @return An API verison agnostic Verifier for verifying the object of the given kind.
-   */
-  private static Verifier getKindVerifier(String kind) {
-    return verifiers.get("*/" + kind.toLowerCase());
-  }
-
-  /**
-   * Gets the verifier for the API object.
-   *
-   * @param apiVersion The Kubernetes API version.
-   * @param kind The Kubernetes object kind.
-   * @return Verifier object for the given apiVersion and Kubernetes object kind.
-   */
-  private static Verifier getVerifier(String apiVersion, String kind) {
-    Verifier verifier = verifiers.get(apiVersion + "/" + kind);
-    if (verifier == null) {
-      verifier = getKindVerifier(kind);
-      if (verifier == null) {
-        verifier = defaultVerifier;
-      }
+    /**
+     * Gets the default verifier for an object kind.
+     *
+     * @param kind The object Kind for the verifier.
+     * @return An API verison agnostic Verifier for verifying the object of the given kind.
+     */
+    private static Verifier getKindVerifier(String kind) {
+        return verifiers.get("*/" + kind.toLowerCase());
     }
-    return verifier;
-  }
 
-  /**
-   * Verify that the Kubernetes object was successfully applied to the Kubernetes cluster.
-   *
-   * @param kubectl The {@link KubectlWrapper} that will query the cluster.
-   * @param object The {@link Manifests.ManifestObject} representation of the Kubernetes object to
-   *     verify.
-   * @return {@link VerificationResult} that encapsulates whether the Kubernetes object was verified
-   *     together with relevant log that is dependent on the type of Kubernetes object.
-   */
-  public static VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
-    Preconditions.checkNotNull(object);
-    return getVerifier(object.getApiVersion(), object.getKind()).verify(kubectl, object);
-  }
+    /**
+     * Gets the verifier for the API object.
+     *
+     * @param apiVersion The Kubernetes API version.
+     * @param kind The Kubernetes object kind.
+     * @return Verifier object for the given apiVersion and Kubernetes object kind.
+     */
+    private static Verifier getVerifier(String apiVersion, String kind) {
+        Verifier verifier = verifiers.get(apiVersion + "/" + kind);
+        if (verifier == null) {
+            verifier = getKindVerifier(kind);
+            if (verifier == null) {
+                verifier = defaultVerifier;
+            }
+        }
+        return verifier;
+    }
 
-  /* Convenience create a failed result with stacktrace of a throwable. */
-  private static VerificationResult errorResult(Throwable t, Manifests.ManifestObject object) {
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    t.printStackTrace(pw);
-    pw.flush();
-    return new VerificationResult(sw.toString(), false, object);
-  }
+    /**
+     * Verify that the Kubernetes object was successfully applied to the Kubernetes cluster.
+     *
+     * @param kubectl The {@link KubectlWrapper} that will query the cluster.
+     * @param object The {@link Manifests.ManifestObject} representation of the Kubernetes object to
+     *     verify.
+     * @return {@link VerificationResult} that encapsulates whether the Kubernetes object was verified
+     *     together with relevant log that is dependent on the type of Kubernetes object.
+     */
+    public static VerificationResult verify(KubectlWrapper kubectl, Manifests.ManifestObject object) {
+        Preconditions.checkNotNull(object);
+        return getVerifier(object.getApiVersion(), object.getKind()).verify(kubectl, object);
+    }
+
+    /* Convenience create a failed result with stacktrace of a throwable. */
+    private static VerificationResult errorResult(Throwable t, Manifests.ManifestObject object) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        pw.flush();
+        return new VerificationResult(sw.toString(), false, object);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/Manifests.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/Manifests.java
@@ -36,205 +36,206 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  * descriptive wrappers, {@link ManifestObject}.
  */
 public class Manifests {
-  private static final String DEFAULT_ENCODING = "UTF-8";
+    private static final String DEFAULT_ENCODING = "UTF-8";
 
-  static Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-  private List<ManifestObject> objects = new ArrayList<ManifestObject>();
+    static Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+    private List<ManifestObject> objects = new ArrayList<ManifestObject>();
 
-  /** ManifestObject wrapper that encapsulates an object spec loaded from a supplied manifest. */
-  public static class ManifestObject {
-    private Map<String, Object> source;
-    private FilePath file;
+    /** ManifestObject wrapper that encapsulates an object spec loaded from a supplied manifest. */
+    public static class ManifestObject {
+        private Map<String, Object> source;
+        private FilePath file;
+
+        /**
+         * Build the manifest object from source.
+         *
+         * @param source The YAML map source for the object.
+         * @param file The file containing the manifest.
+         */
+        public ManifestObject(Map<String, Object> source, FilePath file) {
+            this.source = source;
+            this.file = file;
+        }
+
+        /** @return The file containing this manifest. */
+        public FilePath getFile() {
+            return file;
+        }
+
+        /** @return The YAML map source for the object. */
+        public Map<String, Object> getSource() {
+            return source;
+        }
+
+        /** @return The apiVersion. */
+        public String getApiVersion() {
+            return (String) source.get("apiVersion");
+        }
+
+        /** @return The kind. */
+        public String getKind() {
+            return (String) source.get("kind");
+        }
+
+        /** @return The name. */
+        public Optional<String> getName() {
+            return getMetadata().isPresent()
+                    ? Optional.of((String) getMetadata().get().get("name"))
+                    : Optional.empty();
+        }
+
+        /**
+         * Ensures this {@link ManifestObject} has labels, modifying in-place as needed, finally
+         * returning the labels.
+         *
+         * @return The labels for this {@link ManifestObject}.
+         */
+        @SuppressWarnings("unchecked")
+        public Map<String, String> getOrCreateLabels() {
+            Map<String, Object> metadata = getOrCreateMetadata();
+
+            if (!metadata.containsKey("labels")) {
+                metadata.put("labels", new LinkedHashMap<String, String>());
+            }
+
+            return (Map<String, String>) metadata.get("labels");
+        }
+
+        /**
+         * Adds the specified label key and value to this {@link ManifestObject}'s metadata labels. Will
+         * ensure a label map exists upon execution.
+         *
+         * @param key The key of the label to be added.
+         * @param value The value of the label to be added.
+         */
+        public void addLabel(String key, String value) {
+            Map<String, String> labels = getOrCreateLabels();
+            // Add the specified label ensuring no duplicate values.
+            Set<String> labelValues = labels.get(key) != null
+                    ? new HashSet<>(Arrays.asList(labels.get(key).split(",")))
+                    : new HashSet<>();
+            labelValues.add(value);
+            labels.put(key, String.join(",", labelValues));
+        }
+
+        /** @return The description of the object in {ApiVersion}/{Kind}: {Name} */
+        public String describe() {
+            return String.format(
+                    "%s/%s: %s", getApiVersion(), getKind(), getName().orElse(""));
+        }
+
+        /** @return The metadata map for this {@link ManifestObject}. */
+        @SuppressWarnings("unchecked")
+        private Optional<Map<String, Object>> getMetadata() {
+            return Optional.ofNullable((Map<String, Object>) source.get("metadata"));
+        }
+
+        /**
+         * Returns this {@link ManifestObject}'s metadata, ensuring its existence.
+         *
+         * @return The metadata map for this {@link ManifestObject}.
+         */
+        @SuppressWarnings("unchecked")
+        private Map<String, Object> getOrCreateMetadata() {
+            if (source.get("metadata") == null) {
+                source.put("metadata", new LinkedHashMap<String, Object>());
+            }
+
+            return (Map<String, Object>) source.get("metadata");
+        }
+    }
+
+    /** Private constructor constructs {@link Manifests} from a FilePath. */
+    private Manifests(FilePath filePath) throws IOException, InterruptedException {
+        this(Arrays.asList(new FilePath[] {filePath}));
+    }
+
+    /** Private constructor constructs {@link Manifests} from a list of FilePaths. */
+    private Manifests(List<FilePath> files) throws IOException, InterruptedException {
+        for (FilePath fp : files) {
+            loadFile(fp);
+        }
+    }
 
     /**
-     * Build the manifest object from source.
+     * Factory method for single {@link FilePath}.
      *
-     * @param source The YAML map source for the object.
-     * @param file The file containing the manifest.
+     * @param file The {@link FilePath} containing the manifests.
+     * @return A {@link Manifests} object containing the individual manifests contained at the file
+     *     path.
+     * @throws IOException If an error occurred while loading the file.
+     * @throws InterruptedException If a threading error occurred while loading the file.
      */
-    public ManifestObject(Map<String, Object> source, FilePath file) {
-      this.source = source;
-      this.file = file;
-    }
+    public static Manifests fromFile(FilePath file) throws IOException, InterruptedException {
+        if (file.isDirectory()) {
+            return new Manifests(Arrays.asList(file.list("**/*")));
+        }
 
-    /** @return The file containing this manifest. */
-    public FilePath getFile() {
-      return file;
-    }
-
-    /** @return The YAML map source for the object. */
-    public Map<String, Object> getSource() {
-      return source;
-    }
-
-    /** @return The apiVersion. */
-    public String getApiVersion() {
-      return (String) source.get("apiVersion");
-    }
-
-    /** @return The kind. */
-    public String getKind() {
-      return (String) source.get("kind");
-    }
-
-    /** @return The name. */
-    public Optional<String> getName() {
-      return getMetadata().isPresent()
-          ? Optional.of((String) getMetadata().get().get("name"))
-          : Optional.empty();
+        return new Manifests(file);
     }
 
     /**
-     * Ensures this {@link ManifestObject} has labels, modifying in-place as needed, finally
-     * returning the labels.
+     * Factory method for list of {@link FilePath} objects.
      *
-     * @return The labels for this {@link ManifestObject}.
+     * @param files The list of {@link FilePath} objects containing the manifests.
+     * @return Manifests object constructed based on the list of {@link FilePath}'s.
+     * @throws IOException If an error occurred while loading the file.
+     * @throws InterruptedException If a threading error occurred while loading the file.
      */
+    public static Manifests fromFileList(List<FilePath> files) throws IOException, InterruptedException {
+        return new Manifests(files);
+    }
+
+    /** Loads the file with the given path (Assuming it's a file). */
     @SuppressWarnings("unchecked")
-    public Map<String, String> getOrCreateLabels() {
-      Map<String, Object> metadata = getOrCreateMetadata();
+    private void loadFile(FilePath filePath) throws IOException, InterruptedException {
+        InputStream mis = filePath.read();
+        Iterable<Object> iter = yaml.loadAll(new InputStreamReader(mis, DEFAULT_ENCODING));
+        iter.forEach((o) -> objects.add(new ManifestObject((Map<String, Object>) o, filePath)));
+    }
 
-      if (!metadata.containsKey("labels")) {
-        metadata.put("labels", new LinkedHashMap<String, String>());
-      }
-
-      return (Map<String, String>) metadata.get("labels");
+    /** @return The {@link ManifestObject}'s that were loaded. */
+    public List<ManifestObject> getObjectManifests() {
+        return objects;
     }
 
     /**
-     * Adds the specified label key and value to this {@link ManifestObject}'s metadata labels. Will
-     * ensure a label map exists upon execution.
+     * Get the list of {@link ManifestObject} that match the given kind.
      *
-     * @param key The key of the label to be added.
-     * @param value The value of the label to be added.
+     * @param includedKinds The kinds of Kubernetes objects to include in the list.
+     * @return The manifest objects that match the included kinds.
      */
-    public void addLabel(String key, String value) {
-      Map<String, String> labels = getOrCreateLabels();
-      // Add the specified label ensuring no duplicate values.
-      Set<String> labelValues =
-          labels.get(key) != null
-              ? new HashSet<>(Arrays.asList(labels.get(key).split(",")))
-              : new HashSet<>();
-      labelValues.add(value);
-      labels.put(key, String.join(",", labelValues));
-    }
-
-    /** @return The description of the object in {ApiVersion}/{Kind}: {Name} */
-    public String describe() {
-      return String.format("%s/%s: %s", getApiVersion(), getKind(), getName().orElse(""));
-    }
-
-    /** @return The metadata map for this {@link ManifestObject}. */
-    @SuppressWarnings("unchecked")
-    private Optional<Map<String, Object>> getMetadata() {
-      return Optional.ofNullable((Map<String, Object>) source.get("metadata"));
+    public List<ManifestObject> getObjectManifestsOfKinds(Set<String> includedKinds) {
+        final Set<String> includedKindsLowerCase =
+                includedKinds.stream().map(String::toLowerCase).collect(Collectors.toSet());
+        return getObjectManifests().stream()
+                .filter((manifest) ->
+                        includedKindsLowerCase.contains(manifest.getKind().toLowerCase()))
+                .collect(Collectors.toList());
     }
 
     /**
-     * Returns this {@link ManifestObject}'s metadata, ensuring its existence.
+     * Writes the contents of this {@link Manifests}'s objects back to their corresponding files.
      *
-     * @return The metadata map for this {@link ManifestObject}.
+     * @throws InterruptedException If an error occurred while dumping to YAML.
+     * @throws IOException If an error occurred while writing the file contents.
      */
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> getOrCreateMetadata() {
-      if (source.get("metadata") == null) {
-        source.put("metadata", new LinkedHashMap<String, Object>());
-      }
+    public void write() throws InterruptedException, IOException {
+        Map<FilePath, List<ManifestObject>> fileToManifestListMap = new LinkedHashMap<>();
+        for (ManifestObject manifest : getObjectManifests()) {
+            List<ManifestObject> manifestList =
+                    fileToManifestListMap.getOrDefault(manifest.getFile(), new ArrayList<ManifestObject>());
+            manifestList.add(manifest);
+            fileToManifestListMap.put(manifest.getFile(), manifestList);
+        }
 
-      return (Map<String, Object>) source.get("metadata");
+        for (Map.Entry<FilePath, List<ManifestObject>> entry : fileToManifestListMap.entrySet()) {
+            FilePath file = entry.getKey();
+            List<ManifestObject> manifestObjects = entry.getValue();
+            file.write(
+                    yaml.dumpAll(
+                            manifestObjects.stream().map(m -> m.getSource()).iterator()),
+                    DEFAULT_ENCODING);
+        }
     }
-  }
-
-  /** Private constructor constructs {@link Manifests} from a FilePath. */
-  private Manifests(FilePath filePath) throws IOException, InterruptedException {
-    this(Arrays.asList(new FilePath[] {filePath}));
-  }
-
-  /** Private constructor constructs {@link Manifests} from a list of FilePaths. */
-  private Manifests(List<FilePath> files) throws IOException, InterruptedException {
-    for (FilePath fp : files) {
-      loadFile(fp);
-    }
-  }
-
-  /**
-   * Factory method for single {@link FilePath}.
-   *
-   * @param file The {@link FilePath} containing the manifests.
-   * @return A {@link Manifests} object containing the individual manifests contained at the file
-   *     path.
-   * @throws IOException If an error occurred while loading the file.
-   * @throws InterruptedException If a threading error occurred while loading the file.
-   */
-  public static Manifests fromFile(FilePath file) throws IOException, InterruptedException {
-    if (file.isDirectory()) {
-      return new Manifests(Arrays.asList(file.list("**/*")));
-    }
-
-    return new Manifests(file);
-  }
-
-  /**
-   * Factory method for list of {@link FilePath} objects.
-   *
-   * @param files The list of {@link FilePath} objects containing the manifests.
-   * @return Manifests object constructed based on the list of {@link FilePath}'s.
-   * @throws IOException If an error occurred while loading the file.
-   * @throws InterruptedException If a threading error occurred while loading the file.
-   */
-  public static Manifests fromFileList(List<FilePath> files)
-      throws IOException, InterruptedException {
-    return new Manifests(files);
-  }
-
-  /** Loads the file with the given path (Assuming it's a file). */
-  @SuppressWarnings("unchecked")
-  private void loadFile(FilePath filePath) throws IOException, InterruptedException {
-    InputStream mis = filePath.read();
-    Iterable<Object> iter = yaml.loadAll(new InputStreamReader(mis, DEFAULT_ENCODING));
-    iter.forEach((o) -> objects.add(new ManifestObject((Map<String, Object>) o, filePath)));
-  }
-
-  /** @return The {@link ManifestObject}'s that were loaded. */
-  public List<ManifestObject> getObjectManifests() {
-    return objects;
-  }
-
-  /**
-   * Get the list of {@link ManifestObject} that match the given kind.
-   *
-   * @param includedKinds The kinds of Kubernetes objects to include in the list.
-   * @return The manifest objects that match the included kinds.
-   */
-  public List<ManifestObject> getObjectManifestsOfKinds(Set<String> includedKinds) {
-    final Set<String> includedKindsLowerCase =
-        includedKinds.stream().map(String::toLowerCase).collect(Collectors.toSet());
-    return getObjectManifests().stream()
-        .filter((manifest) -> includedKindsLowerCase.contains(manifest.getKind().toLowerCase()))
-        .collect(Collectors.toList());
-  }
-
-  /**
-   * Writes the contents of this {@link Manifests}'s objects back to their corresponding files.
-   *
-   * @throws InterruptedException If an error occurred while dumping to YAML.
-   * @throws IOException If an error occurred while writing the file contents.
-   */
-  public void write() throws InterruptedException, IOException {
-    Map<FilePath, List<ManifestObject>> fileToManifestListMap = new LinkedHashMap<>();
-    for (ManifestObject manifest : getObjectManifests()) {
-      List<ManifestObject> manifestList =
-          fileToManifestListMap.getOrDefault(manifest.getFile(), new ArrayList<ManifestObject>());
-      manifestList.add(manifest);
-      fileToManifestListMap.put(manifest.getFile(), manifestList);
-    }
-
-    for (Map.Entry<FilePath, List<ManifestObject>> entry : fileToManifestListMap.entrySet()) {
-      FilePath file = entry.getKey();
-      List<ManifestObject> manifestObjects = entry.getValue();
-      file.write(
-          yaml.dumpAll(manifestObjects.stream().map(m -> m.getSource()).iterator()),
-          DEFAULT_ENCODING);
-    }
-  }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ClientUtil.java
@@ -20,54 +20,51 @@ import java.util.Optional;
 /** Utilities for using the gcp-plugin-core clients. */
 public class ClientUtil {
 
-  private static final String APPLICATION_NAME = "jenkins-google-gke-plugin";
+    private static final String APPLICATION_NAME = "jenkins-google-gke-plugin";
 
-  /**
-   * Creates a {@link ClientFactory} for generating the GCP api clients.
-   *
-   * @param itemGroup The Jenkins context to use for retrieving the credentials.
-   * @param domainRequirements A list of domain requirements. Must be non-null.
-   * @param credentialsId The ID of the credentials to use for generating clients.
-   * @param transport An {@link Optional} parameter that specifies the {@link HttpTransport} to use.
-   *     A default will be used if unspecified.
-   * @return A {@link ClientFactory} to get clients.
-   * @throws AbortException If there was an error initializing the ClientFactory.
-   */
-  public static ClientFactory getClientFactory(
-      ItemGroup itemGroup,
-      ImmutableList<DomainRequirement> domainRequirements,
-      String credentialsId,
-      Optional<HttpTransport> transport)
-      throws AbortException {
-    Preconditions.checkNotNull(itemGroup);
-    Preconditions.checkNotNull(domainRequirements);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
-    Preconditions.checkNotNull(transport);
+    /**
+     * Creates a {@link ClientFactory} for generating the GCP api clients.
+     *
+     * @param itemGroup The Jenkins context to use for retrieving the credentials.
+     * @param domainRequirements A list of domain requirements. Must be non-null.
+     * @param credentialsId The ID of the credentials to use for generating clients.
+     * @param transport An {@link Optional} parameter that specifies the {@link HttpTransport} to use.
+     *     A default will be used if unspecified.
+     * @return A {@link ClientFactory} to get clients.
+     * @throws AbortException If there was an error initializing the ClientFactory.
+     */
+    public static ClientFactory getClientFactory(
+            ItemGroup itemGroup,
+            ImmutableList<DomainRequirement> domainRequirements,
+            String credentialsId,
+            Optional<HttpTransport> transport)
+            throws AbortException {
+        Preconditions.checkNotNull(itemGroup);
+        Preconditions.checkNotNull(domainRequirements);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
+        Preconditions.checkNotNull(transport);
 
-    ClientFactory clientFactory;
-    try {
-      GoogleRobotCredentials robotCreds =
-          getRobotCredentials(itemGroup, domainRequirements, credentialsId);
-      Credential googleCredential = getGoogleCredential(robotCreds);
-      clientFactory =
-          new ClientFactory(
-              transport, new RetryHttpInitializerWrapper(googleCredential), APPLICATION_NAME);
-    } catch (IOException | GeneralSecurityException ex) {
-      throw new AbortException(Messages.ClientFactory_FailedToInitializeHTTPTransport(ex));
+        ClientFactory clientFactory;
+        try {
+            GoogleRobotCredentials robotCreds = getRobotCredentials(itemGroup, domainRequirements, credentialsId);
+            Credential googleCredential = getGoogleCredential(robotCreds);
+            clientFactory =
+                    new ClientFactory(transport, new RetryHttpInitializerWrapper(googleCredential), APPLICATION_NAME);
+        } catch (IOException | GeneralSecurityException ex) {
+            throw new AbortException(Messages.ClientFactory_FailedToInitializeHTTPTransport(ex));
+        }
+        return clientFactory;
     }
-    return clientFactory;
-  }
 
-  /**
-   * Creates a {@link ClientFactory} for generating the GCP api clients.
-   *
-   * @param itemGroup The Jenkins context to use for retrieving the credentials.
-   * @param credentialsId The ID of the credentials to use for generating clients.
-   * @return A {@link ClientFactory} to get clients.
-   * @throws AbortException If there was an error initializing the ClientFactory.
-   */
-  public static ClientFactory getClientFactory(ItemGroup itemGroup, String credentialsId)
-      throws AbortException {
-    return getClientFactory(itemGroup, ImmutableList.of(), credentialsId, Optional.empty());
-  }
+    /**
+     * Creates a {@link ClientFactory} for generating the GCP api clients.
+     *
+     * @param itemGroup The Jenkins context to use for retrieving the credentials.
+     * @param credentialsId The ID of the credentials to use for generating clients.
+     * @return A {@link ClientFactory} to get clients.
+     * @throws AbortException If there was an error initializing the ClientFactory.
+     */
+    public static ClientFactory getClientFactory(ItemGroup itemGroup, String credentialsId) throws AbortException {
+        return getClientFactory(itemGroup, ImmutableList.of(), credentialsId, Optional.empty());
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/ContainerScopeRequirement.java
@@ -23,12 +23,12 @@ import java.util.List;
 
 /** Defines the scope requirements for the GKE "Container" API. */
 public class ContainerScopeRequirement extends GoogleOAuth2ScopeRequirement {
-  @Override
-  public Collection<String> getScopes() {
-    List<String> scopes = new ArrayList<>();
-    scopes.addAll(ContainerScopes.all());
-    // E-mail scope for k8s to associate the GCP service account with the e-mail address
-    scopes.add("https://www.googleapis.com/auth/userinfo.email");
-    return scopes;
-  }
+    @Override
+    public Collection<String> getScopes() {
+        List<String> scopes = new ArrayList<>();
+        scopes.addAll(ContainerScopes.all());
+        // E-mail scope for k8s to associate the GCP service account with the e-mail address
+        scopes.add("https://www.googleapis.com/auth/userinfo.email");
+        return scopes;
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/k8sengine/client/RetryHttpInitializerWrapper.java
+++ b/src/main/java/com/google/jenkins/plugins/k8sengine/client/RetryHttpInitializerWrapper.java
@@ -38,62 +38,60 @@ import java.util.logging.Logger;
  */
 public class RetryHttpInitializerWrapper implements HttpRequestInitializer {
 
-  private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
-  private static final int MILLIS_PER_MINUTE = 60 * 1000;
-  private final Credential wrappedCredential;
-  private final Sleeper sleeper;
+    private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
+    private static final int MILLIS_PER_MINUTE = 60 * 1000;
+    private final Credential wrappedCredential;
+    private final Sleeper sleeper;
 
-  /**
-   * A constructor using the default Sleeper.
-   *
-   * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
-   *     project
-   */
-  public RetryHttpInitializerWrapper(Credential wrappedCredential) {
-    this(wrappedCredential, Sleeper.DEFAULT);
-  }
+    /**
+     * A constructor using the default Sleeper.
+     *
+     * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
+     *     project
+     */
+    public RetryHttpInitializerWrapper(Credential wrappedCredential) {
+        this(wrappedCredential, Sleeper.DEFAULT);
+    }
 
-  /**
-   * A constructor used only for testing.
-   *
-   * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
-   *     project
-   * @param sleeper a user-supplied Sleeper
-   */
-  RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
-    this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
-    this.sleeper = sleeper;
-  }
+    /**
+     * A constructor used only for testing.
+     *
+     * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
+     *     project
+     * @param sleeper a user-supplied Sleeper
+     */
+    RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
+        this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
+        this.sleeper = sleeper;
+    }
 
-  /**
-   * Initialize an HttpRequest.
-   *
-   * @param request an HttpRequest that should be initialized
-   */
-  public void initialize(HttpRequest request) {
-    request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
-    final HttpUnsuccessfulResponseHandler backoffHandler =
-        new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
-    request.setInterceptor(wrappedCredential);
-    request.setUnsuccessfulResponseHandler(
-        new HttpUnsuccessfulResponseHandler() {
-          public boolean handleResponse(
-              final HttpRequest request, final HttpResponse response, final boolean supportsRetry)
-              throws IOException {
-            if (wrappedCredential.handleResponse(request, response, supportsRetry)) {
-              // If credential decides it can handle it, the return code or message indicated
-              // something specific to authentication, and no backoff is desired.
-              return true;
-            } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
-              // Otherwise, we defer to the judgement of our internal backoff handler.
-              LOG.info("Retrying " + request.getUrl().toString());
-              return true;
-            } else {
-              return false;
+    /**
+     * Initialize an HttpRequest.
+     *
+     * @param request an HttpRequest that should be initialized
+     */
+    public void initialize(HttpRequest request) {
+        request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
+        final HttpUnsuccessfulResponseHandler backoffHandler =
+                new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
+        request.setInterceptor(wrappedCredential);
+        request.setUnsuccessfulResponseHandler(new HttpUnsuccessfulResponseHandler() {
+            public boolean handleResponse(
+                    final HttpRequest request, final HttpResponse response, final boolean supportsRetry)
+                    throws IOException {
+                if (wrappedCredential.handleResponse(request, response, supportsRetry)) {
+                    // If credential decides it can handle it, the return code or message indicated
+                    // something specific to authentication, and no backoff is desired.
+                    return true;
+                } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
+                    // Otherwise, we defer to the judgement of our internal backoff handler.
+                    LOG.info("Retrying " + request.getUrl().toString());
+                    return true;
+                } else {
+                    return false;
+                }
             }
-          }
         });
-    request.setIOExceptionHandler(
-        new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
-  }
+        request.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/ClusterUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/ClusterUtilTest.java
@@ -22,54 +22,53 @@ import org.junit.Test;
 
 /** Tests for verifying the behavior of {@link ClusterUtil methods} */
 public class ClusterUtilTest {
-  @Test(expected = NullPointerException.class)
-  public void testToNameAndLocationNullCluster() {
-    ClusterUtil.toNameAndLocation(null);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testToNameAndLocationNullCluster() {
+        ClusterUtil.toNameAndLocation(null);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndLocationNullName() {
-    ClusterUtil.toNameAndLocation(null, "us-west1-a");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testToNameAndLocationNullName() {
+        ClusterUtil.toNameAndLocation(null, "us-west1-a");
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndLocationEmptyName() {
-    ClusterUtil.toNameAndLocation("", "us-west1-a");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testToNameAndLocationEmptyName() {
+        ClusterUtil.toNameAndLocation("", "us-west1-a");
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndLocationNullLocation() {
-    ClusterUtil.toNameAndLocation("test-cluster", null);
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testToNameAndLocationNullLocation() {
+        ClusterUtil.toNameAndLocation("test-cluster", null);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testToNameAndLocationEmptyLocation() {
-    ClusterUtil.toNameAndLocation("test-cluster", "");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testToNameAndLocationEmptyLocation() {
+        ClusterUtil.toNameAndLocation("test-cluster", "");
+    }
 
-  @Test
-  public void testToNameAndLocationValidInputs() {
-    assertEquals(
-        "test-cluster (us-west1-a)", ClusterUtil.toNameAndLocation("test-cluster", "us-west1-a"));
-  }
+    @Test
+    public void testToNameAndLocationValidInputs() {
+        assertEquals("test-cluster (us-west1-a)", ClusterUtil.toNameAndLocation("test-cluster", "us-west1-a"));
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndLocationNullInput() {
-    ClusterUtil.valuesFromNameAndLocation(null);
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testValuesFromNameAndLocationNullInput() {
+        ClusterUtil.valuesFromNameAndLocation(null);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndLocationEmptyInput() {
-    ClusterUtil.valuesFromNameAndLocation("");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testValuesFromNameAndLocationEmptyInput() {
+        ClusterUtil.valuesFromNameAndLocation("");
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testValuesFromNameAndLocationMalformedInput() {
-    ClusterUtil.valuesFromNameAndLocation("test us-west1-a");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testValuesFromNameAndLocationMalformedInput() {
+        ClusterUtil.valuesFromNameAndLocation("test us-west1-a");
+    }
 
-  @Test
-  public void testValuesFromNameAndLocationValidInput() {
-    ClusterUtil.valuesFromNameAndLocation("test-cluster (us-west1-a)");
-  }
+    @Test
+    public void testValuesFromNameAndLocationValidInput() {
+        ClusterUtil.valuesFromNameAndLocation("test-cluster (us-west1-a)");
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/CredentialsUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/CredentialsUtilTest.java
@@ -20,67 +20,66 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class CredentialsUtilTest {
-  private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
-  private static final String TEST_INVALID_CREDENTIALS_ID = "test-invalid-credentials-id";
-  private static final String TEST_ACCESS_TOKEN = "test-access-token";
-  @ClassRule public static JenkinsRule r = new JenkinsRule();
+    private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
+    private static final String TEST_INVALID_CREDENTIALS_ID = "test-invalid-credentials-id";
+    private static final String TEST_ACCESS_TOKEN = "test-access-token";
 
-  @Test(expected = AbortException.class)
-  public void testGetRobotCredentialsInvalidCredentialsIdAbortException() throws AbortException {
-    CredentialsUtil.getRobotCredentials(
-        r.jenkins, ImmutableList.<DomainRequirement>of(), TEST_INVALID_CREDENTIALS_ID);
-  }
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
-  @Test(expected = GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class)
-  public void testGetGoogleCredentialAbortException() throws Exception {
-    SecretBytes bytes =
-        SecretBytes.fromBytes(
-            "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8));
-    JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
-    serviceAccountConfig.setSecretJsonKey(bytes);
-    assertNotNull(serviceAccountConfig.getAccountId());
-    GoogleRobotCredentials robotCreds =
-        new GoogleRobotPrivateKeyCredentials(
-            TEST_INVALID_CREDENTIALS_ID, serviceAccountConfig, null);
-    CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
-    store.addCredentials(Domain.global(), robotCreds);
-    CredentialsUtil.getGoogleCredential(robotCreds);
-  }
+    @Test(expected = AbortException.class)
+    public void testGetRobotCredentialsInvalidCredentialsIdAbortException() throws AbortException {
+        CredentialsUtil.getRobotCredentials(
+                r.jenkins, ImmutableList.<DomainRequirement>of(), TEST_INVALID_CREDENTIALS_ID);
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetRobotCredentialsWithEmptyItemGroup() throws AbortException {
-    CredentialsUtil.getRobotCredentials(
-        null, ImmutableList.<DomainRequirement>of(), TEST_CREDENTIALS_ID);
-  }
+    @Test(expected = GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class)
+    public void testGetGoogleCredentialAbortException() throws Exception {
+        SecretBytes bytes =
+                SecretBytes.fromBytes("{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8));
+        JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
+        serviceAccountConfig.setSecretJsonKey(bytes);
+        assertNotNull(serviceAccountConfig.getAccountId());
+        GoogleRobotCredentials robotCreds =
+                new GoogleRobotPrivateKeyCredentials(TEST_INVALID_CREDENTIALS_ID, serviceAccountConfig, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+        store.addCredentials(Domain.global(), robotCreds);
+        CredentialsUtil.getGoogleCredential(robotCreds);
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetRobotCredentialsWithEmptyDomainRequirements() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, null, TEST_CREDENTIALS_ID);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetRobotCredentialsWithEmptyItemGroup() throws AbortException {
+        CredentialsUtil.getRobotCredentials(null, ImmutableList.<DomainRequirement>of(), TEST_CREDENTIALS_ID);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetRobotCredentialsWithNullCredentialsId() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), null);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetRobotCredentialsWithEmptyDomainRequirements() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, null, TEST_CREDENTIALS_ID);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetRobotCredentialsWithEmptyCredentialsId() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), "");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRobotCredentialsWithNullCredentialsId() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), null);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetAccessTokenWithEmptyCredentialsId() throws IOException {
-    CredentialsUtil.getAccessToken("");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRobotCredentialsWithEmptyCredentialsId() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), "");
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetAccessTokenWithNullItemGroup() throws IOException {
-    CredentialsUtil.getAccessToken(null, TEST_CREDENTIALS_ID);
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetAccessTokenWithEmptyCredentialsId() throws IOException {
+        CredentialsUtil.getAccessToken("");
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetAccessTokenWithNullGoogleCredential() throws IOException {
-    Credential googleCredential = null;
-    CredentialsUtil.getAccessToken(googleCredential);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetAccessTokenWithNullItemGroup() throws IOException {
+        CredentialsUtil.getAccessToken(null, TEST_CREDENTIALS_ID);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetAccessTokenWithNullGoogleCredential() throws IOException {
+        Credential googleCredential = null;
+        CredentialsUtil.getAccessToken(googleCredential);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/ITUtil.java
@@ -35,103 +35,102 @@ import org.junit.rules.TemporaryFolder;
 
 /** Provides a library of utility functions for integration tests. */
 public class ITUtil {
-  /**
-   * Formats a random name using the given prefix.
-   *
-   * @param prefix The prefix to be randomly formatted.
-   * @return The randomly formatted name.
-   */
-  static String formatRandomName(String prefix) {
-    return String.format("%s-%s", prefix, UUID.randomUUID().toString().replace("-", ""));
-  }
-
-  /**
-   * Creates a temporary workspace for testing, configuring it as a custom workspace for the
-   * specified {@link Project}.
-   *
-   * @param testProject The {@link Project} the test workspace for.
-   * @return The {@link TemporaryFolder} serving as the test workspace.
-   * @throws IOException If an error occurred while creating the test workspace.
-   */
-  static TemporaryFolder createTestWorkspace(Project testProject) throws IOException {
-    TemporaryFolder testWorkspace = new TemporaryFolder();
-    testWorkspace.create();
-    testProject.setCustomWorkspace(testWorkspace.getRoot().toString());
-    return testWorkspace;
-  }
-
-  /**
-   * Copies the contents of the specified file to the specified directory.
-   *
-   * @param testClass The test class related to the file being copied.
-   * @param toDir The path of the target directory.
-   * @param testFile The test file to copied.
-   * @throws IOException If an error occurred while copying test file.
-   * @throws InterruptedException If an error occurred while copying test file.
-   */
-  static void copyTestFileToDir(Class testClass, String toDir, String testFile)
-      throws IOException, InterruptedException {
-    FilePath dirPath = new FilePath(new File(toDir));
-    String testFileContents = loadResource(testClass, testFile);
-    FilePath testWorkspaceFile = dirPath.child(testFile);
-    testWorkspaceFile.write(testFileContents, StandardCharsets.UTF_8.toString());
-  }
-
-  /**
-   * Loads the content of the specified resource.
-   *
-   * @param testClass The test class the resource is being loaded for.
-   * @param name The name of the resource being loaded.
-   * @return The contents of the loaded resource.
-   * @throws IOException If an error occurred during loading.
-   */
-  static String loadResource(Class testClass, String name) throws IOException {
-    return new String(ByteStreams.toByteArray(testClass.getResourceAsStream(name)));
-  }
-
-  /**
-   * Dumps the logs from the specified {@link Run}.
-   *
-   * @param logger The {@link Logger} to be written to.
-   * @param run The {@link Run} from which the logs will be read.
-   * @throws IOException If an error occurred while dumping the logs.
-   */
-  static void dumpLog(Logger logger, Run<?, ?> run) throws IOException {
-    BufferedReader reader = new BufferedReader(run.getLogReader());
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      logger.info(line);
+    /**
+     * Formats a random name using the given prefix.
+     *
+     * @param prefix The prefix to be randomly formatted.
+     * @return The randomly formatted name.
+     */
+    static String formatRandomName(String prefix) {
+        return String.format("%s-%s", prefix, UUID.randomUUID().toString().replace("-", ""));
     }
-  }
 
-  /**
-   * Retrieves the location set through environment variables
-   *
-   * @return A Google Compute Resource Region (us-west1) or Zone (us-west1-a) string
-   */
-  static String getLocation() {
-    String location = System.getenv("GOOGLE_PROJECT_LOCATION");
-    if (location == null) {
-      location = System.getenv("GOOGLE_PROJECT_ZONE");
+    /**
+     * Creates a temporary workspace for testing, configuring it as a custom workspace for the
+     * specified {@link Project}.
+     *
+     * @param testProject The {@link Project} the test workspace for.
+     * @return The {@link TemporaryFolder} serving as the test workspace.
+     * @throws IOException If an error occurred while creating the test workspace.
+     */
+    static TemporaryFolder createTestWorkspace(Project testProject) throws IOException {
+        TemporaryFolder testWorkspace = new TemporaryFolder();
+        testWorkspace.create();
+        testProject.setCustomWorkspace(testWorkspace.getRoot().toString());
+        return testWorkspace;
     }
-    assertNotNull("GOOGLE_PROJECT_LOCATION env var must be set", location);
-    return location;
-  }
 
-  /**
-   * Retrieves the credentials set through environment variables and converts into a Service Account
-   * configuration for use in the Jenkins credential store.
-   *
-   * @return A {@link ServiceAccountConfig} for the provided Json Key.
-   */
-  public static ServiceAccountConfig getServiceAccountConfig() {
-    String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
-    assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
-    SecretBytes bytes =
-        SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
-    JsonServiceAccountConfig config = new JsonServiceAccountConfig();
-    config.setSecretJsonKey(bytes);
-    assertNotNull(config.getAccountId());
-    return config;
-  }
+    /**
+     * Copies the contents of the specified file to the specified directory.
+     *
+     * @param testClass The test class related to the file being copied.
+     * @param toDir The path of the target directory.
+     * @param testFile The test file to copied.
+     * @throws IOException If an error occurred while copying test file.
+     * @throws InterruptedException If an error occurred while copying test file.
+     */
+    static void copyTestFileToDir(Class testClass, String toDir, String testFile)
+            throws IOException, InterruptedException {
+        FilePath dirPath = new FilePath(new File(toDir));
+        String testFileContents = loadResource(testClass, testFile);
+        FilePath testWorkspaceFile = dirPath.child(testFile);
+        testWorkspaceFile.write(testFileContents, StandardCharsets.UTF_8.toString());
+    }
+
+    /**
+     * Loads the content of the specified resource.
+     *
+     * @param testClass The test class the resource is being loaded for.
+     * @param name The name of the resource being loaded.
+     * @return The contents of the loaded resource.
+     * @throws IOException If an error occurred during loading.
+     */
+    static String loadResource(Class testClass, String name) throws IOException {
+        return new String(ByteStreams.toByteArray(testClass.getResourceAsStream(name)));
+    }
+
+    /**
+     * Dumps the logs from the specified {@link Run}.
+     *
+     * @param logger The {@link Logger} to be written to.
+     * @param run The {@link Run} from which the logs will be read.
+     * @throws IOException If an error occurred while dumping the logs.
+     */
+    static void dumpLog(Logger logger, Run<?, ?> run) throws IOException {
+        BufferedReader reader = new BufferedReader(run.getLogReader());
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            logger.info(line);
+        }
+    }
+
+    /**
+     * Retrieves the location set through environment variables
+     *
+     * @return A Google Compute Resource Region (us-west1) or Zone (us-west1-a) string
+     */
+    static String getLocation() {
+        String location = System.getenv("GOOGLE_PROJECT_LOCATION");
+        if (location == null) {
+            location = System.getenv("GOOGLE_PROJECT_ZONE");
+        }
+        assertNotNull("GOOGLE_PROJECT_LOCATION env var must be set", location);
+        return location;
+    }
+
+    /**
+     * Retrieves the credentials set through environment variables and converts into a Service Account
+     * configuration for use in the Jenkins credential store.
+     *
+     * @return A {@link ServiceAccountConfig} for the provided Json Key.
+     */
+    public static ServiceAccountConfig getServiceAccountConfig() {
+        String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
+        assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
+        SecretBytes bytes = SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
+        JsonServiceAccountConfig config = new JsonServiceAccountConfig();
+        config.setSecretJsonKey(bytes);
+        assertNotNull(config.getAccountId());
+        return config;
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubeConfigTest.java
@@ -43,132 +43,128 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 /** Tests {@link KubeConfig}. */
 @RunWith(MockitoJUnitRunner.class)
 public class KubeConfigTest {
-  @Test
-  public void testContextStringReturnsProperly() {
-    String result = KubeConfig.contextString("testProject", "us-central1-c", "testCluster");
-    assertNotNull(result);
-    assertEquals(result, "gke_testProject_us-central1-c_testCluster");
-  }
+    @Test
+    public void testContextStringReturnsProperly() {
+        String result = KubeConfig.contextString("testProject", "us-central1-c", "testCluster");
+        assertNotNull(result);
+        assertEquals(result, "gke_testProject_us-central1-c_testCluster");
+    }
 
-  @Test
-  public void testClusterServerReturnsProperly() {
-    Cluster cluster = Mockito.mock(Cluster.class);
-    Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
-    String result = KubeConfig.clusterServer(cluster);
-    assertNotNull(result);
-    assertEquals(result, "https://testEndpoint");
-  }
+    @Test
+    public void testClusterServerReturnsProperly() {
+        Cluster cluster = Mockito.mock(Cluster.class);
+        Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
+        String result = KubeConfig.clusterServer(cluster);
+        assertNotNull(result);
+        assertEquals(result, "https://testEndpoint");
+    }
 
-  @Test
-  public void testFromClusterReturnsProperly() throws Exception {
-    Cluster cluster = Mockito.mock(Cluster.class);
-    Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
-    Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
-    Mockito.when(cluster.getName()).thenReturn("testCluster");
-    MasterAuth auth = Mockito.mock(MasterAuth.class);
-    Mockito.when(cluster.getMasterAuth()).thenReturn(auth);
-    Mockito.when(auth.getClusterCaCertificate()).thenReturn("testCaCert");
+    @Test
+    public void testFromClusterReturnsProperly() throws Exception {
+        Cluster cluster = Mockito.mock(Cluster.class);
+        Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
+        Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
+        Mockito.when(cluster.getName()).thenReturn("testCluster");
+        MasterAuth auth = Mockito.mock(MasterAuth.class);
+        Mockito.when(cluster.getMasterAuth()).thenReturn(auth);
+        Mockito.when(auth.getClusterCaCertificate()).thenReturn("testCaCert");
 
-    KubeConfig result = KubeConfig.fromCluster("testProject", cluster, "testAccessToken");
-    assertNotNull(result);
+        KubeConfig result = KubeConfig.fromCluster("testProject", cluster, "testAccessToken");
+        assertNotNull(result);
 
-    String currentContext = result.getCurrentContext();
-    assertNotNull(currentContext);
-    assertEquals(
-        currentContext, KubeConfig.contextString("testProject", "us-central1-c", "testCluster"));
-    assertNotNull(result.getUsers());
-    assertEquals(result.getUsers().size(), 1);
-    assertNotNull(result.getContexts());
-    assertEquals(result.getContexts().size(), 1);
-    assertNotNull(result.getClusters());
-    assertEquals(result.getClusters().size(), 1);
-    // NOTE: The verification of the contents happens in the toYaml test
-  }
+        String currentContext = result.getCurrentContext();
+        assertNotNull(currentContext);
+        assertEquals(currentContext, KubeConfig.contextString("testProject", "us-central1-c", "testCluster"));
+        assertNotNull(result.getUsers());
+        assertEquals(result.getUsers().size(), 1);
+        assertNotNull(result.getContexts());
+        assertEquals(result.getContexts().size(), 1);
+        assertNotNull(result.getClusters());
+        assertEquals(result.getClusters().size(), 1);
+        // NOTE: The verification of the contents happens in the toYaml test
+    }
 
-  @Test
-  public void testToYamlReturnsProperly() throws Exception {
-    Cluster cluster = Mockito.mock(Cluster.class);
-    Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
-    Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
-    Mockito.when(cluster.getName()).thenReturn("testCluster");
-    MasterAuth auth = Mockito.mock(MasterAuth.class);
-    Mockito.when(cluster.getMasterAuth()).thenReturn(auth);
-    Mockito.when(auth.getClusterCaCertificate()).thenReturn("testCaCert");
-    KubeConfig config = KubeConfig.fromCluster("testProject", cluster, "testAccessToken");
-    String result = config.toYaml();
+    @Test
+    public void testToYamlReturnsProperly() throws Exception {
+        Cluster cluster = Mockito.mock(Cluster.class);
+        Mockito.when(cluster.getEndpoint()).thenReturn("testEndpoint");
+        Mockito.when(cluster.getLocation()).thenReturn("us-central1-c");
+        Mockito.when(cluster.getName()).thenReturn("testCluster");
+        MasterAuth auth = Mockito.mock(MasterAuth.class);
+        Mockito.when(cluster.getMasterAuth()).thenReturn(auth);
+        Mockito.when(auth.getClusterCaCertificate()).thenReturn("testCaCert");
+        KubeConfig config = KubeConfig.fromCluster("testProject", cluster, "testAccessToken");
+        String result = config.toYaml();
 
-    StringWriter writer = new StringWriter();
-    PrintWriter printWriter = new PrintWriter(writer);
-    BufferedReader reader =
-        Files.newBufferedReader(
-            Paths.get(KubeConfigTest.class.getResource("/expectedKubeConfig.yml").toURI()));
-    reader.lines().forEach(printWriter::println);
-    printWriter.flush();
-    String expected = writer.toString();
-    assertTrue(yamlEquals(expected, result));
-  }
+        StringWriter writer = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(writer);
+        BufferedReader reader = Files.newBufferedReader(Paths.get(
+                KubeConfigTest.class.getResource("/expectedKubeConfig.yml").toURI()));
+        reader.lines().forEach(printWriter::println);
+        printWriter.flush();
+        String expected = writer.toString();
+        assertTrue(yamlEquals(expected, result));
+    }
 
-  private static boolean yamlEquals(String expectedYaml, String testYaml) throws IOException {
-    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-    Map<String, Object> testConfig = yaml.load(new BufferedReader(new StringReader(testYaml)));
-    Map<String, Object> expectedConfig =
-        yaml.load(new BufferedReader(new StringReader(expectedYaml)));
+    private static boolean yamlEquals(String expectedYaml, String testYaml) throws IOException {
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+        Map<String, Object> testConfig = yaml.load(new BufferedReader(new StringReader(testYaml)));
+        Map<String, Object> expectedConfig = yaml.load(new BufferedReader(new StringReader(expectedYaml)));
 
-    TriFunction<TriFunction, Object, Object, Boolean> deepCollectionEquals =
-        (f, expected, test) -> {
-          if (!expected.getClass().equals(test.getClass())) {
-            return false;
-          }
-
-          if (expected instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> expectedMap = (Map<String, Object>) expected;
-            @SuppressWarnings("unchecked")
-            Map<String, Object> testMap = (Map<String, Object>) test;
-            for (String key : expectedMap.keySet()) {
-
-              @SuppressWarnings("unchecked")
-              Object result = f.apply(f, expectedMap.get(key), testMap.get(key));
-              if (!(Boolean) result) {
+        TriFunction<TriFunction, Object, Object, Boolean> deepCollectionEquals = (f, expected, test) -> {
+            if (!expected.getClass().equals(test.getClass())) {
                 return false;
-              }
-            }
-          }
-
-          if (expected instanceof List) {
-            Iterator expectedItr = ((List) expected).listIterator();
-            Iterator testItr = ((List) test).listIterator();
-            while (expectedItr.hasNext()) {
-              if (!testItr.hasNext()) {
-                return false;
-              }
-
-              @SuppressWarnings("unchecked")
-              Object result = f.apply(f, expectedItr.next(), testItr.next());
-              if (!(Boolean) result) {
-                return false;
-              }
             }
 
-            if (testItr.hasNext()) {
-              return false;
-            }
-          }
+            if (expected instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> expectedMap = (Map<String, Object>) expected;
+                @SuppressWarnings("unchecked")
+                Map<String, Object> testMap = (Map<String, Object>) test;
+                for (String key : expectedMap.keySet()) {
 
-          return expected.equals(test);
+                    @SuppressWarnings("unchecked")
+                    Object result = f.apply(f, expectedMap.get(key), testMap.get(key));
+                    if (!(Boolean) result) {
+                        return false;
+                    }
+                }
+            }
+
+            if (expected instanceof List) {
+                Iterator expectedItr = ((List) expected).listIterator();
+                Iterator testItr = ((List) test).listIterator();
+                while (expectedItr.hasNext()) {
+                    if (!testItr.hasNext()) {
+                        return false;
+                    }
+
+                    @SuppressWarnings("unchecked")
+                    Object result = f.apply(f, expectedItr.next(), testItr.next());
+                    if (!(Boolean) result) {
+                        return false;
+                    }
+                }
+
+                if (testItr.hasNext()) {
+                    return false;
+                }
+            }
+
+            return expected.equals(test);
         };
 
-    return deepCollectionEquals.apply(deepCollectionEquals, expectedConfig, testConfig);
-  }
-
-  @FunctionalInterface
-  interface TriFunction<A, B, C, R> {
-
-    R apply(A a, B b, C c);
-
-    default <V> TriFunction<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
-      Objects.requireNonNull(after);
-      return (A a, B b, C c) -> after.apply(apply(a, b, c));
+        return deepCollectionEquals.apply(deepCollectionEquals, expectedConfig, testConfig);
     }
-  }
+
+    @FunctionalInterface
+    interface TriFunction<A, B, C, R> {
+
+        R apply(A a, B b, C c);
+
+        default <V> TriFunction<A, B, C, V> andThen(Function<? super R, ? extends V> after) {
+            Objects.requireNonNull(after);
+            return (A a, B b, C c) -> after.apply(apply(a, b, c));
+        }
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderClusterTest.java
@@ -46,247 +46,207 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class KubernetesEngineBuilderClusterTest {
-  private static final String TEST_CLUSTER = "testCluster (us-west1-a)";
-  private static final String OTHER_CLUSTER = "otherCluster (us-east1-b)";
+    private static final String TEST_CLUSTER = "testCluster (us-west1-a)";
+    private static final String OTHER_CLUSTER = "otherCluster (us-east1-b)";
 
-  private static Jenkins jenkins;
+    private static Jenkins jenkins;
 
-  @BeforeClass
-  public static void init() {
-    jenkins = Mockito.mock(Jenkins.class);
-  }
-
-  @Test
-  public void testDoFillClusterItemsEmptyWithEmptyCredentialsId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    ListBoxModel expected =
-        initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, null, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillClusterItemsEmptyWithEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    ListBoxModel expected =
-        initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, null);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillClusterItemsErrorMessageWithAbortException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(Messages.KubernetesEngineBuilder_CredentialAuthFailed()),
-            ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillClusterItemsWithIOException() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(Messages.KubernetesEngineBuilder_ClusterFillError()),
-            ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillClusterItemsWithInvalidCluster() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(TEST_CLUSTER), null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, TEST_CLUSTER),
-            ImmutableList.of(EMPTY_VALUE, TEST_CLUSTER));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, "wrong", TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, TEST_CLUSTER);
-  }
-
-  @Test
-  public void testDoFillClusterItemsEmptyWithValidInputsNoClusters() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    ListBoxModel expected =
-        initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, OTHER_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillClusterItemsWithValidInputsOneCluster() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(TEST_CLUSTER), null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, TEST_CLUSTER),
-            ImmutableList.of(EMPTY_VALUE, TEST_CLUSTER));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, TEST_CLUSTER);
-  }
-
-  @Test
-  public void testDoFillClusterItemsWithValidInputsMultipleClusters() throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_CLUSTER, TEST_CLUSTER),
-            ImmutableList.of(EMPTY_VALUE, OTHER_CLUSTER, TEST_CLUSTER));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, OTHER_CLUSTER);
-  }
-
-  @Test
-  public void testDoFillClusterItemsWithValidInputsMultipleClustersAndPreviousValue()
-      throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_CLUSTER, TEST_CLUSTER),
-            ImmutableList.of(EMPTY_VALUE, OTHER_CLUSTER, TEST_CLUSTER));
-    ListBoxModel result =
-        descriptor.doFillClusterItems(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, TEST_CLUSTER);
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithEmptyCluster() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_ClusterRequired(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithEmptyCredentialsId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, null, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ClusterCredentialIDRequired(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, null);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_ClusterProjectIDRequired(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithValidInputsNoClusters() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_NoClusterInProject(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterOkWithValidInputs() throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(FormValidation.ok(), result);
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithAbortException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithIOException() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_ClusterVerificationError(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithAbortExceptionAndEmptyCluster() throws IOException {
-    DescriptorImpl descriptor =
-        setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckClusterMessageWithIOExceptionAndEmptyCluster() throws IOException {
-    DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
-    FormValidation result =
-        descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_ClusterVerificationError(), result.getMessage());
-  }
-
-  private DescriptorImpl setUpClusterDescriptor(
-      List<String> initialClusters, AbortException abortException, IOException ioException)
-      throws IOException {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-
-    if (abortException != null) {
-      Mockito.doThrow(abortException)
-          .when(descriptor)
-          .getClientFactory(any(Jenkins.class), anyString());
-      return descriptor;
+    @BeforeClass
+    public static void init() {
+        jenkins = Mockito.mock(Jenkins.class);
     }
 
-    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
-    Mockito.doReturn(clientFactory)
-        .when(descriptor)
-        .getClientFactory(any(Jenkins.class), anyString());
-
-    ContainerClient containerClient = Mockito.mock(ContainerClient.class);
-    Mockito.when(clientFactory.containerClient()).thenReturn(containerClient);
-
-    if (ioException != null) {
-      Mockito.when(containerClient.listAllClusters(anyString())).thenThrow(ioException);
-      return descriptor;
+    @Test
+    public void testDoFillClusterItemsEmptyWithEmptyCredentialsId() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        ListBoxModel expected = initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, null, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
     }
 
-    List<Cluster> clusters = new ArrayList<>();
+    @Test
+    public void testDoFillClusterItemsEmptyWithEmptyProjectId() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        ListBoxModel expected = initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, null);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+    }
 
-    initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
-    Mockito.when(containerClient.listAllClusters(anyString()))
-        .thenReturn(ImmutableList.copyOf(clusters));
-    return descriptor;
-  }
+    @Test
+    public void testDoFillClusterItemsErrorMessageWithAbortException() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(Messages.KubernetesEngineBuilder_CredentialAuthFailed()),
+                ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+    }
+
+    @Test
+    public void testDoFillClusterItemsWithIOException() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(Messages.KubernetesEngineBuilder_ClusterFillError()), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+    }
+
+    @Test
+    public void testDoFillClusterItemsWithInvalidCluster() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(TEST_CLUSTER), null, null);
+        ListBoxModel expected =
+                initExpected(ImmutableList.of(EMPTY_NAME, TEST_CLUSTER), ImmutableList.of(EMPTY_VALUE, TEST_CLUSTER));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, "wrong", TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, TEST_CLUSTER);
+    }
+
+    @Test
+    public void testDoFillClusterItemsEmptyWithValidInputsNoClusters() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        ListBoxModel expected = initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, OTHER_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+    }
+
+    @Test
+    public void testDoFillClusterItemsWithValidInputsOneCluster() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(TEST_CLUSTER), null, null);
+        ListBoxModel expected =
+                initExpected(ImmutableList.of(EMPTY_NAME, TEST_CLUSTER), ImmutableList.of(EMPTY_VALUE, TEST_CLUSTER));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, TEST_CLUSTER);
+    }
+
+    @Test
+    public void testDoFillClusterItemsWithValidInputsMultipleClusters() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_CLUSTER, TEST_CLUSTER),
+                ImmutableList.of(EMPTY_VALUE, OTHER_CLUSTER, TEST_CLUSTER));
+        ListBoxModel result = descriptor.doFillClusterItems(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, OTHER_CLUSTER);
+    }
+
+    @Test
+    public void testDoFillClusterItemsWithValidInputsMultipleClustersAndPreviousValue() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_CLUSTER, TEST_CLUSTER),
+                ImmutableList.of(EMPTY_VALUE, OTHER_CLUSTER, TEST_CLUSTER));
+        ListBoxModel result =
+                descriptor.doFillClusterItems(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, TEST_CLUSTER);
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithEmptyCluster() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ClusterRequired(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithEmptyCredentialsId() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, null, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ClusterCredentialIDRequired(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithEmptyProjectId() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, null);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ClusterProjectIDRequired(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithValidInputsNoClusters() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_NoClusterInProject(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterOkWithValidInputs() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(OTHER_CLUSTER, TEST_CLUSTER), null, null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(FormValidation.ok(), result);
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithAbortException() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithIOException() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
+        FormValidation result = descriptor.doCheckCluster(jenkins, TEST_CLUSTER, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ClusterVerificationError(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithAbortExceptionAndEmptyCluster() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), new AbortException(), null);
+        FormValidation result = descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckClusterMessageWithIOExceptionAndEmptyCluster() throws IOException {
+        DescriptorImpl descriptor = setUpClusterDescriptor(ImmutableList.of(), null, new IOException());
+        FormValidation result = descriptor.doCheckCluster(jenkins, null, TEST_CREDENTIALS_ID, TEST_PROJECT_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ClusterVerificationError(), result.getMessage());
+    }
+
+    private DescriptorImpl setUpClusterDescriptor(
+            List<String> initialClusters, AbortException abortException, IOException ioException) throws IOException {
+        DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+
+        if (abortException != null) {
+            Mockito.doThrow(abortException).when(descriptor).getClientFactory(any(Jenkins.class), anyString());
+            return descriptor;
+        }
+
+        ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+        Mockito.doReturn(clientFactory).when(descriptor).getClientFactory(any(Jenkins.class), anyString());
+
+        ContainerClient containerClient = Mockito.mock(ContainerClient.class);
+        Mockito.when(clientFactory.containerClient()).thenReturn(containerClient);
+
+        if (ioException != null) {
+            Mockito.when(containerClient.listAllClusters(anyString())).thenThrow(ioException);
+            return descriptor;
+        }
+
+        List<Cluster> clusters = new ArrayList<>();
+
+        initialClusters.forEach(c -> clusters.add(ClusterUtil.fromNameAndLocation(c)));
+        Mockito.when(containerClient.listAllClusters(anyString())).thenReturn(ImmutableList.copyOf(clusters));
+        return descriptor;
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderIT.java
@@ -51,253 +51,229 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Tests {@link KubernetesEngineBuilder}. */
 public class KubernetesEngineBuilderIT {
-  private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilderIT.class.getName());
-  private static final String TEST_DEPLOYMENT_MANIFEST = "testDeployment.yml";
-  private static final String TEST_DEPLOYMENT_MALFORMED_MANIFEST = "testMalformedDeployment.yml";
-  private static final String TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST =
-      "testUnverifiableDeployment.yml";
+    private static final Logger LOGGER = Logger.getLogger(KubernetesEngineBuilderIT.class.getName());
+    private static final String TEST_DEPLOYMENT_MANIFEST = "testDeployment.yml";
+    private static final String TEST_DEPLOYMENT_MALFORMED_MANIFEST = "testMalformedDeployment.yml";
+    private static final String TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST = "testUnverifiableDeployment.yml";
 
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-  private static String clusterName;
-  private static String projectId;
-  private static String testLocation;
-  private static String credentialsId;
-  private static ContainerClient client;
+    private static String clusterName;
+    private static String projectId;
+    private static String testLocation;
+    private static String credentialsId;
+    private static ContainerClient client;
 
-  @BeforeClass
-  public static void init() throws Exception {
-    LOGGER.info("Initializing KubernetesEngineBuilderIT");
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Initializing KubernetesEngineBuilderIT");
 
-    projectId = System.getenv("GOOGLE_PROJECT_ID");
-    assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
+        projectId = System.getenv("GOOGLE_PROJECT_ID");
+        assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
 
-    testLocation = getLocation();
+        testLocation = getLocation();
 
-    clusterName = System.getenv("GOOGLE_GKE_CLUSTER");
-    assertNotNull("GOOGLE_GKE_CLUSTER env var must be set", clusterName);
+        clusterName = System.getenv("GOOGLE_GKE_CLUSTER");
+        assertNotNull("GOOGLE_GKE_CLUSTER env var must be set", clusterName);
 
-    LOGGER.info("Creating credentials");
-    ServiceAccountConfig sac = getServiceAccountConfig();
-    credentialsId = projectId;
-    Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
-    CredentialsStore store =
-        new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
-    store.addCredentials(Domain.global(), c);
+        LOGGER.info("Creating credentials");
+        ServiceAccountConfig sac = getServiceAccountConfig();
+        credentialsId = projectId;
+        Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
+        store.addCredentials(Domain.global(), c);
 
-    LOGGER.info("Creating container client");
-    client = ClientUtil.getClientFactory(jenkinsRule.jenkins, credentialsId).containerClient();
-  }
+        LOGGER.info("Creating container client");
+        client = ClientUtil.getClientFactory(jenkinsRule.jenkins, credentialsId).containerClient();
+    }
 
-  @Test
-  public void testServiceDeploymentSucceeds() throws Exception {
-    LOGGER.info("Testing service deployment succeeds");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
-      gkeBuilder.pushAfterBuildStep(
-          (kubeConfig, run, workspace, launcher, listener) -> {
-            KubectlWrapper kubectl =
-                new KubectlWrapper.Builder()
+    @Test
+    public void testServiceDeploymentSucceeds() throws Exception {
+        LOGGER.info("Testing service deployment succeeds");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
+            gkeBuilder.pushAfterBuildStep((kubeConfig, run, workspace, launcher, listener) -> {
+                KubectlWrapper kubectl = new KubectlWrapper.Builder()
+                        .workspace(workspace)
+                        .launcher(launcher)
+                        .kubeConfig(kubeConfig)
+                        .namespace("default")
+                        .build();
+                Object json = kubectl.getObject("deployment", "nginx-deployment");
+                Map<String, Object> labels = JsonPath.read(json, "metadata.labels");
+                assertNotNull(labels);
+                assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                String labelValues = (String) labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY);
+                assertTrue(Arrays.asList(labelValues.split(",")).contains(KubernetesEngineBuilder.METRICS_LABEL_VALUE));
+            });
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatusSuccess(jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testWellFormedFailedDeploymentNotVerified() throws Exception {
+        LOGGER.info("Testing well-formed unverifiable deployment fails verification");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST);
+            copyTestFileToDir(
+                    getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testServiceDeploymentFailsBadCluster() throws Exception {
+        LOGGER.info("Testing service deployment fails bad cluster");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            gkeBuilder.setClusterName(formatRandomName("bad-cluster"));
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testServiceDeploymentFailsBadProjectId() throws Exception {
+        LOGGER.info("Testing service deployment fails bad project id");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            gkeBuilder.setProjectId(formatRandomName("bad-project"));
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testServiceDeploymentFailsBadCredentialId() throws Exception {
+        LOGGER.info("Testing service deployment fails bad credential id");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            gkeBuilder.setCredentialsId(formatRandomName("bad-credential"));
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testServiceDeploymentFailsBadManifestPattern() throws Exception {
+        LOGGER.info("Testing service deployment fails bad manifest pattern");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            gkeBuilder.setManifestPattern(formatRandomName("bad-manifest-pattern.yml"));
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    @Test
+    public void testServiceDeploymentFailsMalformedManifest() throws Exception {
+        LOGGER.info("Testing service fails malformed manifest");
+        FreeStyleProject testJenkinsProject = jenkinsRule.createFreeStyleProject(formatRandomName("test"));
+        createTestWorkspace(testJenkinsProject);
+        try {
+            KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
+            gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_MALFORMED_MANIFEST);
+            testJenkinsProject.getBuildersList().add(gkeBuilder);
+            copyTestFileToDir(getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MALFORMED_MANIFEST);
+
+            FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
+            assertNotNull(build);
+            jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
+            dumpLog(LOGGER, build);
+        } finally {
+            testJenkinsProject.delete();
+        }
+    }
+
+    private static KubernetesEngineBuilder getDefaultGKEBuilder() {
+        KubernetesEngineBuilder gkeBuilder = new KubernetesEngineBuilder();
+        gkeBuilder.setProjectId(projectId);
+        gkeBuilder.setClusterName(clusterName);
+        gkeBuilder.setCredentialsId(credentialsId);
+        gkeBuilder.setLocation(testLocation);
+        gkeBuilder.setNamespace("");
+        gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_MANIFEST);
+        gkeBuilder.setVerifyDeployments(true);
+        gkeBuilder.setVerifyTimeoutInMinutes(1);
+        gkeBuilder.pushAfterBuildStep((kubeConfig, run, workspace, launcher, listener) -> {
+            KubectlWrapper kubectl = new KubectlWrapper.Builder()
                     .workspace(workspace)
-                    .launcher(launcher)
                     .kubeConfig(kubeConfig)
-                    .namespace("default")
+                    .launcher(launcher)
+                    .namespace("")
                     .build();
-            Object json = kubectl.getObject("deployment", "nginx-deployment");
-            Map<String, Object> labels = JsonPath.read(json, "metadata.labels");
-            assertNotNull(labels);
-            assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-            String labelValues = (String) labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY);
-            assertTrue(
-                Arrays.asList(labelValues.split(","))
-                    .contains(KubernetesEngineBuilder.METRICS_LABEL_VALUE));
-          });
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatusSuccess(jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testWellFormedFailedDeploymentNotVerified() throws Exception {
-    LOGGER.info("Testing well-formed unverifiable deployment fails verification");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST);
-      copyTestFileToDir(
-          getClass(),
-          testJenkinsProject.getCustomWorkspace(),
-          TEST_DEPLOYMENT_UNVERIFIABLE_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testServiceDeploymentFailsBadCluster() throws Exception {
-    LOGGER.info("Testing service deployment fails bad cluster");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      gkeBuilder.setClusterName(formatRandomName("bad-cluster"));
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testServiceDeploymentFailsBadProjectId() throws Exception {
-    LOGGER.info("Testing service deployment fails bad project id");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      gkeBuilder.setProjectId(formatRandomName("bad-project"));
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testServiceDeploymentFailsBadCredentialId() throws Exception {
-    LOGGER.info("Testing service deployment fails bad credential id");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      gkeBuilder.setCredentialsId(formatRandomName("bad-credential"));
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testServiceDeploymentFailsBadManifestPattern() throws Exception {
-    LOGGER.info("Testing service deployment fails bad manifest pattern");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      gkeBuilder.setManifestPattern(formatRandomName("bad-manifest-pattern.yml"));
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  @Test
-  public void testServiceDeploymentFailsMalformedManifest() throws Exception {
-    LOGGER.info("Testing service fails malformed manifest");
-    FreeStyleProject testJenkinsProject =
-        jenkinsRule.createFreeStyleProject(formatRandomName("test"));
-    createTestWorkspace(testJenkinsProject);
-    try {
-      KubernetesEngineBuilder gkeBuilder = getDefaultGKEBuilder();
-      gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_MALFORMED_MANIFEST);
-      testJenkinsProject.getBuildersList().add(gkeBuilder);
-      copyTestFileToDir(
-          getClass(), testJenkinsProject.getCustomWorkspace(), TEST_DEPLOYMENT_MALFORMED_MANIFEST);
-
-      FreeStyleBuild build = testJenkinsProject.scheduleBuild2(0).get();
-      assertNotNull(build);
-      jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(build));
-      dumpLog(LOGGER, build);
-    } finally {
-      testJenkinsProject.delete();
-    }
-  }
-
-  private static KubernetesEngineBuilder getDefaultGKEBuilder() {
-    KubernetesEngineBuilder gkeBuilder = new KubernetesEngineBuilder();
-    gkeBuilder.setProjectId(projectId);
-    gkeBuilder.setClusterName(clusterName);
-    gkeBuilder.setCredentialsId(credentialsId);
-    gkeBuilder.setLocation(testLocation);
-    gkeBuilder.setNamespace("");
-    gkeBuilder.setManifestPattern(TEST_DEPLOYMENT_MANIFEST);
-    gkeBuilder.setVerifyDeployments(true);
-    gkeBuilder.setVerifyTimeoutInMinutes(1);
-    gkeBuilder.pushAfterBuildStep(
-        (kubeConfig, run, workspace, launcher, listener) -> {
-          KubectlWrapper kubectl =
-              new KubectlWrapper.Builder()
-                  .workspace(workspace)
-                  .kubeConfig(kubeConfig)
-                  .launcher(launcher)
-                  .namespace("")
-                  .build();
-          Set<String> objectKinds = new HashSet<>();
-          Manifests manifests =
-              Manifests.fromFile(workspace.child(gkeBuilder.getManifestPattern()));
-          manifests.getObjectManifests().stream().forEach(mo -> objectKinds.add(mo.getKind()));
-          for (String kind : objectKinds) {
-            kubectl.runKubectlCommand(
-                "delete",
-                new ImmutableList.Builder<String>()
-                    .add(kind.toLowerCase())
-                    .addAll(
-                        manifests.getObjectManifests().stream()
-                            .filter(mo -> mo.getName().isPresent())
-                            .map(mo -> mo.getName().get())
-                            .collect(Collectors.toList()))
-                    .build());
-          }
+            Set<String> objectKinds = new HashSet<>();
+            Manifests manifests = Manifests.fromFile(workspace.child(gkeBuilder.getManifestPattern()));
+            manifests.getObjectManifests().stream().forEach(mo -> objectKinds.add(mo.getKind()));
+            for (String kind : objectKinds) {
+                kubectl.runKubectlCommand(
+                        "delete",
+                        new ImmutableList.Builder<String>()
+                                .add(kind.toLowerCase())
+                                .addAll(manifests.getObjectManifests().stream()
+                                        .filter(mo -> mo.getName().isPresent())
+                                        .map(mo -> mo.getName().get())
+                                        .collect(Collectors.toList()))
+                                .build());
+            }
         });
-    return gkeBuilder;
-  }
+        return gkeBuilder;
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderMetricsLabelTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderMetricsLabelTest.java
@@ -35,237 +35,200 @@ import org.yaml.snakeyaml.Yaml;
 /** Tests the Kubernetes metrics label behaviors within {@link KubernetesEngineBuilder}. */
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesEngineBuilderMetricsLabelTest {
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelProperlyAddsLabel() throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Deployment",
-                        "metadata:",
-                        "  name: nginx-deployment",
-                        "  labels:",
-                        "    app: nginx")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelProperlyAddsLabel() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(String.join(
+                                "\n",
+                                "apiVersion: apps/v1",
+                                "kind: Deployment",
+                                "metadata:",
+                                "  name: nginx-deployment",
+                                "  labels:",
+                                "    app: nginx")
+                        .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              Manifests.ManifestObject manifest =
-                  new Manifests.ManifestObject(
-                      (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]),
-                      manifestFile);
-              Map<String, String> labels = manifest.getOrCreateLabels();
-              assertNotNull(labels);
-              assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-              assertEquals(
-                  labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
-                  KubernetesEngineBuilder.METRICS_LABEL_VALUE);
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    Manifests.ManifestObject manifest = new Manifests.ManifestObject(
+                            (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]), manifestFile);
+                    Map<String, String> labels = manifest.getOrCreateLabels();
+                    assertNotNull(labels);
+                    assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                    assertEquals(
+                            labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
+                            KubernetesEngineBuilder.METRICS_LABEL_VALUE);
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelProperlyAppendsToExistingManagedByLabel()
-      throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Deployment",
-                        "metadata:",
-                        "  name: nginx-deployment",
-                        "  labels:",
-                        "    app: nginx",
-                        "    app.kubernetes.io/managed-by: helm")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelProperlyAppendsToExistingManagedByLabel() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(String.join(
+                                "\n",
+                                "apiVersion: apps/v1",
+                                "kind: Deployment",
+                                "metadata:",
+                                "  name: nginx-deployment",
+                                "  labels:",
+                                "    app: nginx",
+                                "    app.kubernetes.io/managed-by: helm")
+                        .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              Manifests.ManifestObject manifest =
-                  new Manifests.ManifestObject(
-                      (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]),
-                      manifestFile);
-              Map<String, String> labels = manifest.getOrCreateLabels();
-              assertNotNull(labels);
-              assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-              List<String> managedByLabelValues =
-                  Arrays.asList(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY).split(","));
-              assertTrue(
-                  managedByLabelValues.contains(KubernetesEngineBuilder.METRICS_LABEL_VALUE));
-              assertTrue(managedByLabelValues.contains("helm"));
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    Manifests.ManifestObject manifest = new Manifests.ManifestObject(
+                            (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]), manifestFile);
+                    Map<String, String> labels = manifest.getOrCreateLabels();
+                    assertNotNull(labels);
+                    assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                    List<String> managedByLabelValues =
+                            Arrays.asList(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY)
+                                    .split(","));
+                    assertTrue(managedByLabelValues.contains(KubernetesEngineBuilder.METRICS_LABEL_VALUE));
+                    assertTrue(managedByLabelValues.contains("helm"));
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelProperlyAddsToMissingLabels()
-      throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Service",
-                        "metadata:",
-                        "  name: nginx-service")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelProperlyAddsToMissingLabels() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(
+                        String.join("\n", "apiVersion: apps/v1", "kind: Service", "metadata:", "  name: nginx-service")
+                                .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              Manifests.ManifestObject manifest =
-                  new Manifests.ManifestObject(
-                      (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]),
-                      manifestFile);
-              Map<String, String> labels = manifest.getOrCreateLabels();
-              assertNotNull(labels);
-              assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-              assertEquals(
-                  labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
-                  KubernetesEngineBuilder.METRICS_LABEL_VALUE);
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    Manifests.ManifestObject manifest = new Manifests.ManifestObject(
+                            (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]), manifestFile);
+                    Map<String, String> labels = manifest.getOrCreateLabels();
+                    assertNotNull(labels);
+                    assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                    assertEquals(
+                            labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
+                            KubernetesEngineBuilder.METRICS_LABEL_VALUE);
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelProperlyHandlesExistingMetricsLabel()
-      throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Service",
-                        "metadata:",
-                        "  name: nginx-service",
-                        "  app.kubernetes.io/managed-by: graphite-jenkins-gke")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelProperlyHandlesExistingMetricsLabel() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(String.join(
+                                "\n",
+                                "apiVersion: apps/v1",
+                                "kind: Service",
+                                "metadata:",
+                                "  name: nginx-service",
+                                "  app.kubernetes.io/managed-by: graphite-jenkins-gke")
+                        .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              Manifests.ManifestObject manifest =
-                  new Manifests.ManifestObject(
-                      (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]),
-                      manifestFile);
-              Map<String, String> labels = manifest.getOrCreateLabels();
-              assertNotNull(labels);
-              assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-              assertEquals(
-                  labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
-                  KubernetesEngineBuilder.METRICS_LABEL_VALUE);
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    Manifests.ManifestObject manifest = new Manifests.ManifestObject(
+                            (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]), manifestFile);
+                    Map<String, String> labels = manifest.getOrCreateLabels();
+                    assertNotNull(labels);
+                    assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                    assertEquals(
+                            labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
+                            KubernetesEngineBuilder.METRICS_LABEL_VALUE);
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelProperlyHandlesMultipleObjects()
-      throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Service",
-                        "metadata:",
-                        "  name: nginx-service",
-                        "\n",
-                        "---",
-                        "apiVersion: apps/v1",
-                        "kind: Deployment",
-                        "metadata:",
-                        "  name: nginx-deployment",
-                        "\n",
-                        "---",
-                        "apiVersion: apps/v1",
-                        "kind: ReplicaSet",
-                        "metadata:",
-                        "  name: nginx-replicaset")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelProperlyHandlesMultipleObjects() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(String.join(
+                                "\n",
+                                "apiVersion: apps/v1",
+                                "kind: Service",
+                                "metadata:",
+                                "  name: nginx-service",
+                                "\n",
+                                "---",
+                                "apiVersion: apps/v1",
+                                "kind: Deployment",
+                                "metadata:",
+                                "  name: nginx-deployment",
+                                "\n",
+                                "---",
+                                "apiVersion: apps/v1",
+                                "kind: ReplicaSet",
+                                "metadata:",
+                                "  name: nginx-replicaset")
+                        .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              for (Object yamlObj : yaml.loadAll((String) invocation.getArguments()[0])) {
-                Manifests.ManifestObject manifest =
-                    new Manifests.ManifestObject((Map<String, Object>) yamlObj, manifestFile);
-                Map<String, String> labels = manifest.getOrCreateLabels();
-                assertNotNull(labels);
-                assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-                assertEquals(
-                    labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
-                    KubernetesEngineBuilder.METRICS_LABEL_VALUE);
-              }
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    for (Object yamlObj : yaml.loadAll((String) invocation.getArguments()[0])) {
+                        Manifests.ManifestObject manifest =
+                                new Manifests.ManifestObject((Map<String, Object>) yamlObj, manifestFile);
+                        Map<String, String> labels = manifest.getOrCreateLabels();
+                        assertNotNull(labels);
+                        assertNotNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                        assertEquals(
+                                labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY),
+                                KubernetesEngineBuilder.METRICS_LABEL_VALUE);
+                    }
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testAddMetricsLabelDoesNotAddLabelProperly()
-      throws IOException, InterruptedException {
-    FilePath manifestFile = Mockito.mock(FilePath.class);
-    Mockito.when(manifestFile.read())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.join(
-                        "\n",
-                        "apiVersion: apps/v1",
-                        "kind: Ingress",
-                        "metadata:",
-                        "  name: nginx-ingress",
-                        "  labels:",
-                        "    app: nginx")
-                    .getBytes()));
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAddMetricsLabelDoesNotAddLabelProperly() throws IOException, InterruptedException {
+        FilePath manifestFile = Mockito.mock(FilePath.class);
+        Mockito.when(manifestFile.read())
+                .thenReturn(new ByteArrayInputStream(String.join(
+                                "\n",
+                                "apiVersion: apps/v1",
+                                "kind: Ingress",
+                                "metadata:",
+                                "  name: nginx-ingress",
+                                "  labels:",
+                                "    app: nginx")
+                        .getBytes()));
 
-    Mockito.doAnswer(
-            invocation -> {
-              Yaml yaml = new Yaml();
-              Manifests.ManifestObject manifest =
-                  new Manifests.ManifestObject(
-                      (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]),
-                      manifestFile);
-              Map<String, String> labels = manifest.getOrCreateLabels();
-              assertNotNull(labels);
-              assertNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
-              return null;
-            })
-        .when(manifestFile)
-        .write(anyString(), anyString());
-    KubernetesEngineBuilder.addMetricsLabel(manifestFile);
-  }
+        Mockito.doAnswer(invocation -> {
+                    Yaml yaml = new Yaml();
+                    Manifests.ManifestObject manifest = new Manifests.ManifestObject(
+                            (Map<String, Object>) yaml.load((String) invocation.getArguments()[0]), manifestFile);
+                    Map<String, String> labels = manifest.getOrCreateLabels();
+                    assertNotNull(labels);
+                    assertNull(labels.get(KubernetesEngineBuilder.METRICS_LABEL_KEY));
+                    return null;
+                })
+                .when(manifestFile)
+                .write(anyString(), anyString());
+        KubernetesEngineBuilder.addMetricsLabel(manifestFile);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderNamespaceTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderNamespaceTest.java
@@ -26,43 +26,43 @@ import org.junit.Test;
 /** Tests for handling of namespaces in {@link KubernetesEngineBuilder}. */
 public class KubernetesEngineBuilderNamespaceTest {
 
-  @Test
-  public void testDoCheckNamespaceOKWithNull() {
-    DescriptorImpl descriptor = new DescriptorImpl();
-    FormValidation result = descriptor.doCheckNamespace(null);
-    assertNotNull(result);
-    assertEquals(FormValidation.ok().getMessage(), result.getMessage());
-  }
+    @Test
+    public void testDoCheckNamespaceOKWithNull() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        FormValidation result = descriptor.doCheckNamespace(null);
+        assertNotNull(result);
+        assertEquals(FormValidation.ok().getMessage(), result.getMessage());
+    }
 
-  @Test
-  public void testDoCheckNamespaceOKWithEmptyString() {
-    DescriptorImpl descriptor = new DescriptorImpl();
-    FormValidation result = descriptor.doCheckNamespace("");
-    assertNotNull(result);
-    assertEquals(FormValidation.ok().getMessage(), result.getMessage());
-  }
+    @Test
+    public void testDoCheckNamespaceOKWithEmptyString() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        FormValidation result = descriptor.doCheckNamespace("");
+        assertNotNull(result);
+        assertEquals(FormValidation.ok().getMessage(), result.getMessage());
+    }
 
-  @Test
-  public void testDoCheckNamespaceWithOKProperlyFormedString() {
-    DescriptorImpl descriptor = new DescriptorImpl();
-    FormValidation result = descriptor.doCheckNamespace("test-a-23-b");
-    assertNotNull(result);
-    assertEquals(FormValidation.ok().getMessage(), result.getMessage());
-  }
+    @Test
+    public void testDoCheckNamespaceWithOKProperlyFormedString() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        FormValidation result = descriptor.doCheckNamespace("test-a-23-b");
+        assertNotNull(result);
+        assertEquals(FormValidation.ok().getMessage(), result.getMessage());
+    }
 
-  @Test
-  public void testDoCheckNamespaceErrorWithValidCharactersMalformedString() {
-    DescriptorImpl descriptor = new DescriptorImpl();
-    FormValidation result = descriptor.doCheckNamespace("-test");
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_NamespaceInvalid(), result.getMessage());
-  }
+    @Test
+    public void testDoCheckNamespaceErrorWithValidCharactersMalformedString() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        FormValidation result = descriptor.doCheckNamespace("-test");
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_NamespaceInvalid(), result.getMessage());
+    }
 
-  @Test
-  public void testDoCheckNamespaceErrorWithInvalidCharacters() {
-    DescriptorImpl descriptor = new DescriptorImpl();
-    FormValidation result = descriptor.doCheckNamespace("*");
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_NamespaceInvalid(), result.getMessage());
-  }
+    @Test
+    public void testDoCheckNamespaceErrorWithInvalidCharacters() {
+        DescriptorImpl descriptor = new DescriptorImpl();
+        FormValidation result = descriptor.doCheckNamespace("*");
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_NamespaceInvalid(), result.getMessage());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesEngineBuilderTest.java
@@ -44,304 +44,258 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KubernetesEngineBuilderTest {
-  static final String TEST_PROJECT_ID = "test-project-id";
-  static final String OTHER_PROJECT_ID = "other-project-id";
-  static final String TEST_CREDENTIALS_ID = "test-credentials-id";
+    static final String TEST_PROJECT_ID = "test-project-id";
+    static final String OTHER_PROJECT_ID = "other-project-id";
+    static final String TEST_CREDENTIALS_ID = "test-credentials-id";
 
-  private static Jenkins jenkins;
+    private static Jenkins jenkins;
 
-  // TODO(#49): Separate out tests into separate classes for better organization.
+    // TODO(#49): Separate out tests into separate classes for better organization.
 
-  @BeforeClass
-  public static void init() {
-    jenkins = Mockito.mock(Jenkins.class);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsErrorMessageWithAbortException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(Messages.KubernetesEngineBuilder_CredentialAuthFailed()),
-            ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsErrorMessageWithIOException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(Messages.KubernetesEngineBuilder_ProjectIDFillError()),
-            ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsEmptyWithEmptyCredentialsId() throws IOException {
-    DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
-    ListBoxModel expected =
-        initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
-    ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, null);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsWithValidCredentialsId() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(
-            ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
-
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
-            ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, TEST_PROJECT_ID);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndDefault()
-      throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(
-            ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
-            ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    ListBoxModel result =
-        descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, OTHER_PROJECT_ID);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndEmptyDefault()
-      throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), "", null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
-            ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    ListBoxModel result =
-        descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, OTHER_PROJECT_ID);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsWithValidCredentialsIdMissingDefaultProject()
-      throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID), TEST_PROJECT_ID, null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
-            ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, OTHER_PROJECT_ID);
-  }
-
-  @Test
-  public void testDoFillProjectIdItemsWithValidCredentialsAndEmptyProject() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(
-            ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
-    ListBoxModel expected =
-        initExpected(
-            ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
-            ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
-    ListBoxModel result =
-        descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertListBoxModelEquals(expected, result);
-    assertValueSelected(result, OTHER_PROJECT_ID);
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithEmptyProjectID() throws IOException {
-    DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
-    FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_ProjectIDRequired(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithEmptyCredentialsID() throws IOException {
-    DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
-    FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, null);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ProjectCredentialIDRequired(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithAbortException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
-    FormValidation result =
-        descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithIOException() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
-    FormValidation result =
-        descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ProjectIDVerificationError(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithAbortExceptionAndEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
-    FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithIOExceptionAndEmptyProjectId() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
-    FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ProjectIDVerificationError(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithNoProjects() throws IOException {
-    DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
-    FormValidation result =
-        descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithWrongProjects() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID), "", null, null);
-    FormValidation result =
-        descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckProjectIdMessageWithValidProject() throws IOException {
-    DescriptorImpl descriptor =
-        setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), "", null, null);
-    FormValidation result =
-        descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
-    assertNotNull(result);
-    assertEquals(FormValidation.ok().getMessage(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckVerifyTimeoutInMinutesNAN() {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-    FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("abc");
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckVerifyTimeoutInMinutesZero() {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-    FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("0");
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError(), result.getMessage());
-  }
-
-  @Test
-  public void testDoCheckVerifyTimeoutInMinutesEmpty() {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-    FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("");
-    assertNotNull(result);
-    assertEquals(
-        Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesRequired(), result.getMessage());
-  }
-
-  private DescriptorImpl setUpProjectDescriptor(
-      List<String> initialProjects,
-      String defaultProjectId,
-      AbortException abortException,
-      IOException ioException)
-      throws IOException {
-    DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
-
-    if (abortException != null) {
-      Mockito.doThrow(abortException)
-          .when(descriptor)
-          .getClientFactory(any(Jenkins.class), anyString());
-      return descriptor;
+    @BeforeClass
+    public static void init() {
+        jenkins = Mockito.mock(Jenkins.class);
     }
 
-    ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
-    Mockito.doReturn(clientFactory)
-        .when(descriptor)
-        .getClientFactory(any(Jenkins.class), anyString());
-
-    Mockito.doReturn(defaultProjectId)
-        .when(descriptor)
-        .getDefaultProjectId(any(Jenkins.class), anyString());
-
-    CloudResourceManagerClient cloudResourceManagerClient =
-        Mockito.mock(CloudResourceManagerClient.class);
-    Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
-
-    if (ioException != null) {
-      Mockito.when(cloudResourceManagerClient.listProjects()).thenThrow(ioException);
-      return descriptor;
+    @Test
+    public void testDoFillProjectIdItemsErrorMessageWithAbortException() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(Messages.KubernetesEngineBuilder_CredentialAuthFailed()),
+                ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
     }
 
-    List<Project> projects = new ArrayList<>();
-    initialProjects.forEach(p -> projects.add(new Project().setProjectId(p)));
-    Mockito.when(cloudResourceManagerClient.listProjects())
-        .thenReturn(ImmutableList.copyOf(projects));
-    return descriptor;
-  }
-
-  static ListBoxModel initExpected(List<String> expectedNames, List<String> expectedValues) {
-    ListBoxModel expected = new ListBoxModel();
-    for (int i = 0; i < expectedNames.size(); i++) {
-      expected.add(expectedNames.get(i), expectedValues.get(i));
+    @Test
+    public void testDoFillProjectIdItemsErrorMessageWithIOException() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(Messages.KubernetesEngineBuilder_ProjectIDFillError()), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
     }
-    return expected;
-  }
 
-  static void assertListBoxModelEquals(ListBoxModel expected, ListBoxModel result) {
-    for (int i = 0; i < expected.size(); i++) {
-      assertEquals(expected.get(i).name, result.get(i).name);
-      assertEquals(expected.get(i).value, result.get(i).value);
+    @Test
+    public void testDoFillProjectIdItemsEmptyWithEmptyCredentialsId() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
+        ListBoxModel expected = initExpected(ImmutableList.of(EMPTY_NAME), ImmutableList.of(EMPTY_VALUE));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, null);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
     }
-  }
 
-  static void assertValueSelected(ListBoxModel result, String expectedValue) {
-    Optional<Option> expectedOption =
-        result.stream().filter(i -> expectedValue.equals(i.value)).findFirst();
-    expectedOption.ifPresent(option -> assertTrue(option.selected));
-  }
+    @Test
+    public void testDoFillProjectIdItemsWithValidCredentialsId() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(
+                ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
+
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+                ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, TEST_PROJECT_ID);
+    }
+
+    @Test
+    public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndDefault() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(
+                ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+                ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, OTHER_PROJECT_ID);
+    }
+
+    @Test
+    public void testDoFillProjectIdItemsWithValidCredentialsIdAndPreviousValueAndEmptyDefault() throws IOException {
+        DescriptorImpl descriptor =
+                setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), "", null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+                ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, OTHER_PROJECT_ID);
+    }
+
+    @Test
+    public void testDoFillProjectIdItemsWithValidCredentialsIdMissingDefaultProject() throws IOException {
+        DescriptorImpl descriptor =
+                setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID), TEST_PROJECT_ID, null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+                ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, null, TEST_CREDENTIALS_ID);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, OTHER_PROJECT_ID);
+    }
+
+    @Test
+    public void testDoFillProjectIdItemsWithValidCredentialsAndEmptyProject() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(
+                ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), TEST_PROJECT_ID, null, null);
+        ListBoxModel expected = initExpected(
+                ImmutableList.of(EMPTY_NAME, OTHER_PROJECT_ID, TEST_PROJECT_ID),
+                ImmutableList.of(EMPTY_VALUE, OTHER_PROJECT_ID, TEST_PROJECT_ID));
+        ListBoxModel result = descriptor.doFillProjectIdItems(jenkins, OTHER_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertListBoxModelEquals(expected, result);
+        assertValueSelected(result, OTHER_PROJECT_ID);
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithEmptyProjectID() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectIDRequired(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithEmptyCredentialsID() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, null);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectCredentialIDRequired(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithAbortException() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithIOException() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectIDVerificationError(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithAbortExceptionAndEmptyProjectId() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", new AbortException(), null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_CredentialAuthFailed(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithIOExceptionAndEmptyProjectId() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, new IOException());
+        FormValidation result = descriptor.doCheckProjectId(jenkins, null, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectIDVerificationError(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithNoProjects() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(), "", null, null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithWrongProjects() throws IOException {
+        DescriptorImpl descriptor = setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID), "", null, null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_ProjectIDNotUnderCredential(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckProjectIdMessageWithValidProject() throws IOException {
+        DescriptorImpl descriptor =
+                setUpProjectDescriptor(ImmutableList.of(OTHER_PROJECT_ID, TEST_PROJECT_ID), "", null, null);
+        FormValidation result = descriptor.doCheckProjectId(jenkins, TEST_PROJECT_ID, TEST_CREDENTIALS_ID);
+        assertNotNull(result);
+        assertEquals(FormValidation.ok().getMessage(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckVerifyTimeoutInMinutesNAN() {
+        DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+        FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("abc");
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckVerifyTimeoutInMinutesZero() {
+        DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+        FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("0");
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesFormatError(), result.getMessage());
+    }
+
+    @Test
+    public void testDoCheckVerifyTimeoutInMinutesEmpty() {
+        DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+        FormValidation result = descriptor.doCheckVerifyTimeoutInMinutes("");
+        assertNotNull(result);
+        assertEquals(Messages.KubernetesEngineBuilder_VerifyTimeoutInMinutesRequired(), result.getMessage());
+    }
+
+    private DescriptorImpl setUpProjectDescriptor(
+            List<String> initialProjects,
+            String defaultProjectId,
+            AbortException abortException,
+            IOException ioException)
+            throws IOException {
+        DescriptorImpl descriptor = Mockito.spy(DescriptorImpl.class);
+
+        if (abortException != null) {
+            Mockito.doThrow(abortException).when(descriptor).getClientFactory(any(Jenkins.class), anyString());
+            return descriptor;
+        }
+
+        ClientFactory clientFactory = Mockito.mock(ClientFactory.class);
+        Mockito.doReturn(clientFactory).when(descriptor).getClientFactory(any(Jenkins.class), anyString());
+
+        Mockito.doReturn(defaultProjectId).when(descriptor).getDefaultProjectId(any(Jenkins.class), anyString());
+
+        CloudResourceManagerClient cloudResourceManagerClient = Mockito.mock(CloudResourceManagerClient.class);
+        Mockito.when(clientFactory.cloudResourceManagerClient()).thenReturn(cloudResourceManagerClient);
+
+        if (ioException != null) {
+            Mockito.when(cloudResourceManagerClient.listProjects()).thenThrow(ioException);
+            return descriptor;
+        }
+
+        List<Project> projects = new ArrayList<>();
+        initialProjects.forEach(p -> projects.add(new Project().setProjectId(p)));
+        Mockito.when(cloudResourceManagerClient.listProjects()).thenReturn(ImmutableList.copyOf(projects));
+        return descriptor;
+    }
+
+    static ListBoxModel initExpected(List<String> expectedNames, List<String> expectedValues) {
+        ListBoxModel expected = new ListBoxModel();
+        for (int i = 0; i < expectedNames.size(); i++) {
+            expected.add(expectedNames.get(i), expectedValues.get(i));
+        }
+        return expected;
+    }
+
+    static void assertListBoxModelEquals(ListBoxModel expected, ListBoxModel result) {
+        for (int i = 0; i < expected.size(); i++) {
+            assertEquals(expected.get(i).name, result.get(i).name);
+            assertEquals(expected.get(i).value, result.get(i).value);
+        }
+    }
+
+    static void assertValueSelected(ListBoxModel result, String expectedValue) {
+        Optional<Option> expectedOption =
+                result.stream().filter(i -> expectedValue.equals(i.value)).findFirst();
+        expectedOption.ifPresent(option -> assertTrue(option.selected));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/KubernetesVerifiersTest.java
@@ -28,59 +28,53 @@ import org.mockito.Mockito;
 
 /** Tests {@link com.google.jenkins.plugins.k8sengine.KubernetesVerifiers} */
 public class KubernetesVerifiersTest {
-  private static final String VERIFIABLE_DEPLOYMENT_OUTPUT = "verifiableDeploymentOutput.json";
-  private static final String UNVERIFIABLE_DEPLOYMENT_OUTPUT = "unverifiableDeploymentOutput.json";
+    private static final String VERIFIABLE_DEPLOYMENT_OUTPUT = "verifiableDeploymentOutput.json";
+    private static final String UNVERIFIABLE_DEPLOYMENT_OUTPUT = "unverifiableDeploymentOutput.json";
 
-  @Test
-  public void testGoodDeploymentVerified() throws Exception {
-    Object goodDeploymentOutput = readTestFile(VERIFIABLE_DEPLOYMENT_OUTPUT);
-    KubectlWrapper kubectl = Mockito.mock(KubectlWrapper.class);
-    Mockito.when(kubectl.getObject("deployment", "nginx-deployment"))
-        .thenReturn(goodDeploymentOutput);
+    @Test
+    public void testGoodDeploymentVerified() throws Exception {
+        Object goodDeploymentOutput = readTestFile(VERIFIABLE_DEPLOYMENT_OUTPUT);
+        KubectlWrapper kubectl = Mockito.mock(KubectlWrapper.class);
+        Mockito.when(kubectl.getObject("deployment", "nginx-deployment")).thenReturn(goodDeploymentOutput);
 
-    Manifests.ManifestObject goodDeployment = Mockito.mock(Manifests.ManifestObject.class);
-    Mockito.when(goodDeployment.getKind()).thenReturn("deployment");
-    Mockito.when(goodDeployment.getName()).thenReturn(Optional.<String>of("nginx-deployment"));
-    Mockito.when(goodDeployment.getApiVersion()).thenReturn("apps/v1");
-    KubernetesVerifiers.VerificationResult result =
-        KubernetesVerifiers.verify(kubectl, goodDeployment);
-    assertTrue(result.isVerified());
-    Integer availableReplicas = JsonPath.read(goodDeploymentOutput, "status.availableReplicas");
-    Integer minimumReplicas = JsonPath.read(goodDeploymentOutput, "spec.replicas");
-    String shouldBeInLog =
-        String.format(
-            "AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
-    String verificationLog = result.toString();
-    assertTrue(verificationLog.contains(shouldBeInLog));
-  }
+        Manifests.ManifestObject goodDeployment = Mockito.mock(Manifests.ManifestObject.class);
+        Mockito.when(goodDeployment.getKind()).thenReturn("deployment");
+        Mockito.when(goodDeployment.getName()).thenReturn(Optional.<String>of("nginx-deployment"));
+        Mockito.when(goodDeployment.getApiVersion()).thenReturn("apps/v1");
+        KubernetesVerifiers.VerificationResult result = KubernetesVerifiers.verify(kubectl, goodDeployment);
+        assertTrue(result.isVerified());
+        Integer availableReplicas = JsonPath.read(goodDeploymentOutput, "status.availableReplicas");
+        Integer minimumReplicas = JsonPath.read(goodDeploymentOutput, "spec.replicas");
+        String shouldBeInLog =
+                String.format("AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
+        String verificationLog = result.toString();
+        assertTrue(verificationLog.contains(shouldBeInLog));
+    }
 
-  @Test
-  public void testBadDeploymentNotVerified() throws Exception {
-    Object badDeploymentOutput = readTestFile(UNVERIFIABLE_DEPLOYMENT_OUTPUT);
-    KubectlWrapper kubectl = Mockito.mock(KubectlWrapper.class);
-    Mockito.when(kubectl.getObject("deployment", "nginx-deployment-unverifiable"))
-        .thenReturn(badDeploymentOutput);
+    @Test
+    public void testBadDeploymentNotVerified() throws Exception {
+        Object badDeploymentOutput = readTestFile(UNVERIFIABLE_DEPLOYMENT_OUTPUT);
+        KubectlWrapper kubectl = Mockito.mock(KubectlWrapper.class);
+        Mockito.when(kubectl.getObject("deployment", "nginx-deployment-unverifiable"))
+                .thenReturn(badDeploymentOutput);
 
-    Manifests.ManifestObject badDeployment = Mockito.mock(Manifests.ManifestObject.class);
-    Mockito.when(badDeployment.getKind()).thenReturn("deployment");
-    Mockito.when(badDeployment.getName())
-        .thenReturn(Optional.<String>of("nginx-deployment-unverifiable"));
-    Mockito.when(badDeployment.getApiVersion()).thenReturn("apps/v1");
-    KubernetesVerifiers.VerificationResult result =
-        KubernetesVerifiers.verify(kubectl, badDeployment);
-    assertFalse(result.isVerified());
+        Manifests.ManifestObject badDeployment = Mockito.mock(Manifests.ManifestObject.class);
+        Mockito.when(badDeployment.getKind()).thenReturn("deployment");
+        Mockito.when(badDeployment.getName()).thenReturn(Optional.<String>of("nginx-deployment-unverifiable"));
+        Mockito.when(badDeployment.getApiVersion()).thenReturn("apps/v1");
+        KubernetesVerifiers.VerificationResult result = KubernetesVerifiers.verify(kubectl, badDeployment);
+        assertFalse(result.isVerified());
 
-    Integer minimumReplicas = JsonPath.read(badDeploymentOutput, "spec.replicas");
-    Integer availableReplicas = 0;
-    String shouldBeInLog =
-        String.format(
-            "AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
-    String verificationLog = result.toString();
-    assertTrue(verificationLog.contains(shouldBeInLog));
-  }
+        Integer minimumReplicas = JsonPath.read(badDeploymentOutput, "spec.replicas");
+        Integer availableReplicas = 0;
+        String shouldBeInLog =
+                String.format("AvailableReplicas = %s, MinimumReplicas = %s", availableReplicas, minimumReplicas);
+        String verificationLog = result.toString();
+        assertTrue(verificationLog.contains(shouldBeInLog));
+    }
 
-  private static Object readTestFile(String name) throws IOException {
-    String jsonString = Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);
-    return Configuration.defaultConfiguration().jsonProvider().parse(jsonString);
-  }
+    private static Object readTestFile(String name) throws IOException {
+        String jsonString = Resources.toString(Resources.getResource(name), StandardCharsets.UTF_8);
+        return Configuration.defaultConfiguration().jsonProvider().parse(jsonString);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientUtilIT.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientUtilIT.java
@@ -38,38 +38,37 @@ import org.jvnet.hudson.test.JenkinsRule;
 /** Integration tests for {@link ClientUtil}. * */
 public class ClientUtilIT {
 
-  private static Logger LOGGER = Logger.getLogger(ClientUtilIT.class.getName());
+    private static Logger LOGGER = Logger.getLogger(ClientUtilIT.class.getName());
 
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-  private static String credentialsId;
+    private static String credentialsId;
 
-  @BeforeClass
-  public static void init() throws Exception {
-    LOGGER.info("Starting ClientUtil test.");
-    String projectId = System.getenv("GOOGLE_PROJECT_ID");
-    assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
-    ServiceAccountConfig sac = getServiceAccountConfig();
-    credentialsId = projectId;
-    Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
-    CredentialsStore store =
-        new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
-    store.addCredentials(Domain.global(), c);
-  }
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Starting ClientUtil test.");
+        String projectId = System.getenv("GOOGLE_PROJECT_ID");
+        assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
+        ServiceAccountConfig sac = getServiceAccountConfig();
+        credentialsId = projectId;
+        Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
+        store.addCredentials(Domain.global(), c);
+    }
 
-  @Test
-  public void testGetClientFactoryValidCreds() throws AbortException {
-    ClientFactory factory =
-        ClientUtil.getClientFactory(
-            jenkinsRule.jenkins, ImmutableList.of(), credentialsId, Optional.empty());
-    assertNotNull(factory);
-    assertNotNull(factory.containerClient());
-  }
+    @Test
+    public void testGetClientFactoryValidCreds() throws AbortException {
+        ClientFactory factory =
+                ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), credentialsId, Optional.empty());
+        assertNotNull(factory);
+        assertNotNull(factory.containerClient());
+    }
 
-  @Test
-  public void testGetClientFactoryShortValidCreds() throws AbortException {
-    ClientFactory factory = ClientUtil.getClientFactory(jenkinsRule.jenkins, credentialsId);
-    assertNotNull(factory);
-    assertNotNull(factory.containerClient());
-  }
+    @Test
+    public void testGetClientFactoryShortValidCreds() throws AbortException {
+        ClientFactory factory = ClientUtil.getClientFactory(jenkinsRule.jenkins, credentialsId);
+        assertNotNull(factory);
+        assertNotNull(factory.containerClient());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/k8sengine/client/ClientUtilTest.java
@@ -26,66 +26,66 @@ import org.jvnet.hudson.test.JenkinsRule;
 /** Test suite for {@link ClientUtil}. */
 public class ClientUtilTest {
 
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-  private static final String TEST_CREDENTIALS_ID = "test-project";
+    private static final String TEST_CREDENTIALS_ID = "test-project";
 
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryNullJenkins() throws AbortException {
-    ClientUtil.getClientFactory(null, ImmutableList.of(), TEST_CREDENTIALS_ID, Optional.empty());
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryShortNullJenkins() throws AbortException {
-    ClientUtil.getClientFactory(null, TEST_CREDENTIALS_ID);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryNullDomainRequirements() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, null, TEST_CREDENTIALS_ID, Optional.empty());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetClientFactoryNullCredentialsId() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), null, Optional.empty());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetClientFactoryShortNullCredentialsId() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetClientFactoryEmptyCredentialsId() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), "", Optional.empty());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetClientFactoryShortEmptyCredentialsId() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, "");
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryFailsWithInvalidCredentialsId() throws Throwable {
-    try {
-      ClientUtil.getClientFactory(
-          jenkinsRule.jenkins, ImmutableList.of(), "fake", Optional.empty());
-    } catch (AbortException e) {
-      throw e.getCause();
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryNullJenkins() throws AbortException {
+        ClientUtil.getClientFactory(null, ImmutableList.of(), TEST_CREDENTIALS_ID, Optional.empty());
     }
-  }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryShortFailsWithInvalidCredentialsId() throws Throwable {
-    try {
-      ClientUtil.getClientFactory(jenkinsRule.jenkins, "fake");
-    } catch (AbortException e) {
-      throw e.getCause();
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryShortNullJenkins() throws AbortException {
+        ClientUtil.getClientFactory(null, TEST_CREDENTIALS_ID);
     }
-  }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetClientFactoryTransportNull() throws AbortException {
-    ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), TEST_CREDENTIALS_ID, null);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryNullDomainRequirements() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, null, TEST_CREDENTIALS_ID, Optional.empty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetClientFactoryNullCredentialsId() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), null, Optional.empty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetClientFactoryShortNullCredentialsId() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetClientFactoryEmptyCredentialsId() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), "", Optional.empty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetClientFactoryShortEmptyCredentialsId() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, "");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryFailsWithInvalidCredentialsId() throws Throwable {
+        try {
+            ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), "fake", Optional.empty());
+        } catch (AbortException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryShortFailsWithInvalidCredentialsId() throws Throwable {
+        try {
+            ClientUtil.getClientFactory(jenkinsRule.jenkins, "fake");
+        } catch (AbortException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetClientFactoryTransportNull() throws AbortException {
+        ClientUtil.getClientFactory(jenkinsRule.jenkins, ImmutableList.of(), TEST_CREDENTIALS_ID, null);
+    }
 }


### PR DESCRIPTION
This repository uses a non-standard (for the Jenkins project) code formatting style and enforcement during the build. This PR switches this repository to use the Jenkins standard project-wide formatting configuration and enforcement with Spotless. The benefit is that it makes it easier for Jenkins developers to go from one project to the next without the cognitive dissonance of switching styles.

### Testing done

Ran `mvn clean verify -DskipTests -DskipITs`.