### PR TITLE
Bump `google.http.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <gitHubRepo>jenkinsci/google-kubernetes-engine-plugin</gitHubRepo>
     <jenkins.version>2.401.3</jenkins.version>
     <google.api.version>1.25.0</google.api.version>
-    <google.http.version>1.42.2</google.http.version>
+    <google.http.version>1.43.3</google.http.version>
     <cloudresourcemanager.revision>572</cloudresourcemanager.revision>
     <container.revision>93</container.revision>
     <gcp-plugin-core.version>0.3.0</gcp-plugin-core.version>


### PR DESCRIPTION
Routine dependency bump. The new versions is consistent with other Google plugins in the Update Center. The only testing I have done is the CI build.