### PR TITLE
Ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <container.revision>93</container.revision>
     <gcp-plugin-core.version>0.3.0</gcp-plugin-core.version>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### Ban JUnit 4 imports

To prevent regressions when adding new tests, https://github.com/jenkinsci/plugin-pom/pull/1178 introduced a new flag that enables a Maven Enforcer rule banning `org.junit.*` imports while allowing `org.junit.jupiter.*`.

With this change, the build will fail if any `org.junit.*` imports are introduced.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed